### PR TITLE
Fix label in worker deployment

### DIFF
--- a/charts/dify/templates/worker-deployment.yaml
+++ b/charts/dify/templates/worker-deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     descriptions: worker
   labels:
 {{- include "dify.labels" . | nindent 4 }}
-    component: api
+    component: worker
     # app: {{ template "dify.worker.fullname" . }}
 {{ include "dify.ud.labels" . | indent 4 }}
   name: {{ template "dify.worker.fullname" . }}
@@ -16,7 +16,7 @@ spec:
   selector:
     matchLabels:
 {{- include "dify.selectorLabels" . | nindent 6 }}
-      component: api
+      component: worker
       {{/*
       # Required labels for istio
       # app: {{ template "dify.worker.fullname" . }}
@@ -28,7 +28,7 @@ spec:
 {{ include "dify.ud.annotations" . | indent 8 }}
       labels:
 {{- include "dify.selectorLabels" . | nindent 8 }}
-        component: api
+        component: worker
         {{/*
         # Required labels for istio
         # app: {{ template "dify.worker.fullname" . }}


### PR DESCRIPTION
## NOTICE
End users may **NOT** be able to migrate their helm release from previous versions with single `helm upgrade` command. A `helm unstall <release-name>` followed by a `helm install <the-very-same-release-name>` should do the trick, while introducing minor downtime.