### PR TITLE
 Dify 0.4.9 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,11 @@ helm install my-release dify/dify
 - [ ] object storage
 - [x] weaviate
 - [ ] qdrant
+- [ ] milvus
 ### External components that can be used by this app with proper configuration
 - [x] redis
 - [x] postgresql
 - [x] object storage
 - [x] weaviate
 - [x] qdrant
+- [X] milvus

--- a/charts/dify/Chart.yaml
+++ b/charts/dify/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.16.1
+version: 0.17.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/dify/templates/_helpers.tpl
+++ b/charts/dify/templates/_helpers.tpl
@@ -40,7 +40,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{/*
-Create a default fully qualified worker name.
+Create a default fully qualified web name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "dify.web.fullname" -}}

--- a/charts/dify/templates/config.tpl
+++ b/charts/dify/templates/config.tpl
@@ -341,6 +341,10 @@ server {
       proxy_pass http://{{ template "dify.api.fullname" .}}:{{ .Values.api.service.port }};
       include proxy.conf;
     }
+    location /files {
+      proxy_pass http://{{ template "dify.api.fullname" .}}:{{ .Values.api.service.port }};
+      include proxy.conf;
+    }
 
     location / {
       proxy_pass http://{{ template "dify.web.fullname" .}}:{{ .Values.web.service.port }};

--- a/charts/dify/templates/config.tpl
+++ b/charts/dify/templates/config.tpl
@@ -242,12 +242,12 @@ WEAVIATE_API_KEY: {{ first .Values.weaviate.authentication.apikey.allowed_keys }
 
 {{- define "dify.mail.config" -}}
 # Mail configuration, support: resend
-MAIL_TYPE: ''
+MAIL_TYPE: {{ .Values.api.mail.type | quote }}
 # default send from email address, if not specified
-MAIL_DEFAULT_SEND_FROM: 'YOUR EMAIL FROM (eg: no-reply <no-reply@dify.ai>)'
+MAIL_DEFAULT_SEND_FROM: {{ .Values.api.mail.defaultSender | quote }}
 # the api-key for resend (https://resend.com)
-RESEND_API_KEY: ''
-RESEND_API_URL: https://api.resend.com
+RESEND_API_KEY: {{ .Values.api.mail.resendApiKey | quote }}
+RESEND_API_URL: {{ .Values.api.mail.resendApiUrl | quote }}
 {{- end }}
 
 {{- define "dify.nginx.config.proxy" }}

--- a/charts/dify/templates/config.tpl
+++ b/charts/dify/templates/config.tpl
@@ -54,9 +54,9 @@ CONSOLE_CORS_ALLOW_ORIGINS: '*'
 # you must use the HTTPS protocol and set the configuration to `SameSite=None, Secure=true, HttpOnly=true`.
 #
 
-{{- include "dify.storage.config" . }}
-{{- include "dify.vectordb.config" . }}
-{{- include "dify.mail.config" . }}
+{{ include "dify.storage.config" . }}
+{{ include "dify.vectordb.config" . }}
+{{ include "dify.mail.config" . }}
 # The DSN for Sentry error reporting. If not set, Sentry error reporting will be disabled.
 SENTRY_DSN: ''
 # The sample rate for Sentry events. Default: `1.0`
@@ -83,14 +83,14 @@ SECRET_KEY: {{ .Values.api.secretKey }}
 {{ include "dify.db.config" . }}
 
 # The configurations of redis cache connection.
-{{- include "dify.redis.config" . }}
+{{ include "dify.redis.config" . }}
 # The configurations of celery broker.
-{{- include "dify.celery.config" . }}
+{{ include "dify.celery.config" . }}
 
-{{- include "dify.storage.config" . }}
+{{ include "dify.storage.config" . }}
 # The Vector store configurations.
-{{- include "dify.vectordb.config" . }}
-{{- include "dify.mail.config" . }}
+{{ include "dify.vectordb.config" . }}
+{{ include "dify.mail.config" . }}
 {{- end }}
 
 {{- define "dify.db.config" -}}
@@ -178,7 +178,7 @@ CELERY_BROKER_URL: {{ printf "redis://:%s@%s:%v/1" .auth.password $redisHost .ma
 {{- end }}
 {{- end }}
 
-{{- define "dify.vectordb.config" }}
+{{- define "dify.vectordb.config" -}}
 {{- if .Values.externalWeaviate.enabled }}
 # The type of vector store to use. Supported values are `weaviate`, `qdrant`, `milvus`.
 VECTOR_STORE: weaviate
@@ -197,33 +197,34 @@ QDRANT_CLIENT_TIMEOUT: 20
 # The DSN for Sentry error reporting. If not set, Sentry error reporting will be disabled.
 {{- else if .Values.externalMilvus.enabled}}
 # Milvus configuration Only available when VECTOR_STORE is `milvus`.
+VECTOR_STORE: milvus
 # The milvus host.
-MILVUS_HOST: 127.0.0.1
+MILVUS_HOST: {{ .Values.externalMilvus.host }}
 # The milvus host.
-MILVUS_PORT: 19530
+MILVUS_PORT: {{ .Values.externalMilvus.port | toString }}
 # The milvus username.
-MILVUS_USER: root
+MILVUS_USER: {{ .Values.externalMilvus.user }}
 # The milvus password.
-MILVUS_PASSWORD: Milvus
+MILVUS_PASSWORD: {{ .Values.externalMilvus.password }}
 # The milvus tls switch.
-MILVUS_SECURE: 'false'
+MILVUS_SECURE: {{ .Values.externalMilvus.useTLS | toString }}
 {{- else if .Values.weaviate.enabled }}
 # The type of vector store to use. Supported values are `weaviate`, `qdrant`, `milvus`.
 VECTOR_STORE: weaviate
-{{- with .Values.weaviate.service }}
-{{- if and (eq .type "ClusterIP") (not (eq .clusterIP "None"))}}
+  {{- with .Values.weaviate.service }}
+    {{- if and (eq .type "ClusterIP") (not (eq .clusterIP "None"))}}
 # The Weaviate endpoint URL. Only available when VECTOR_STORE is `weaviate`.
 {{/*
 Pitfall: scheme (i.e.) must be supecified, or weviate client won't function as
 it depends on `hostname` from urllib.parse.urlparse will be empty if schema is not specified.
 */}}
 WEAVIATE_ENDPOINT: {{ printf "http://%s" .name | quote }}
-{{- end }}
-{{- end }}
+    {{- end }}
+  {{- end }}
 # The Weaviate API key.
-{{- if .Values.weaviate.authentication.apikey }}
+  {{- if .Values.weaviate.authentication.apikey }}
 WEAVIATE_API_KEY: {{ first .Values.weaviate.authentication.apikey.allowed_keys }}
-{{- end }}
+  {{- end }}
 {{- end }}
 {{- end }}
 

--- a/charts/dify/templates/config.tpl
+++ b/charts/dify/templates/config.tpl
@@ -8,23 +8,23 @@ SECRET_KEY: {{ .Values.api.secretKey }}
 # The base URL of console application web frontend, refers to the Console base URL of WEB service if console domain is
 # different from api or web app domain.
 # example: http://cloud.dify.ai
-CONSOLE_WEB_URL: {{ .Values.api.url.console | quote }}
+CONSOLE_WEB_URL: {{ .Values.api.url.consoleWeb | quote }}
 # The base URL of console application api server, refers to the Console base URL of WEB service if console domain is
 # different from api or web app domain.
 # example: http://cloud.dify.ai
-CONSOLE_API_URL: {{ .Values.api.url.console | quote }}
+CONSOLE_API_URL: {{ .Values.api.url.consoleApi | quote }}
 # The URL prefix for Service API endpoints, refers to the base URL of the current API service if api domain is
 # different from console domain.
 # example: http://api.dify.ai
-SERVICE_API_URL: {{ .Values.api.url.api | quote }}
+SERVICE_API_URL: {{ .Values.api.url.serviceApi | quote }}
 # The URL prefix for Web APP frontend, refers to the Web App base URL of WEB service if web app domain is different from
 # console or api domain.
 # example: http://udify.app
-APP_WEB_URL: {{ .Values.api.url.app | quote }}
+APP_WEB_URL: {{ .Values.api.url.appWeb | quote }}
 # File preview or download Url prefix.
 # used to display File preview or download Url to the front-end or as Multi-model inputs;
 # Url is signed and has expiration time.
-FILES_URL: ''
+FILES_URL: {{ .Values.api.url.files }}
 # When enabled, migrations will be executed prior to application startup and the application will start after the migrations have completed.
 MIGRATION_ENABLED: {{ .Values.api.migration | toString | quote }}
 
@@ -91,6 +91,18 @@ SECRET_KEY: {{ .Values.api.secretKey }}
 # The Vector store configurations.
 {{ include "dify.vectordb.config" . }}
 {{ include "dify.mail.config" . }}
+{{- end }}
+
+{{- define "dify.web.config" -}}
+# The base URL of console application api server, refers to the Console base URL of WEB service if console domain is
+# different from api or web app domain.
+# example: http://cloud.dify.ai
+CONSOLE_API_URL: {{ .Values.api.url.consoleApi}}
+# The URL for Web APP api server, refers to the Web App base URL of WEB service if web app domain is different from
+# console or api domain.
+# example: http://udify.app
+APP_API_URL: {{ .Values.api.url.appApi }}
+# The DSN for Sentry
 {{- end }}
 
 {{- define "dify.db.config" -}}

--- a/charts/dify/templates/config.tpl
+++ b/charts/dify/templates/config.tpl
@@ -97,7 +97,7 @@ SECRET_KEY: {{ .Values.api.secretKey }}
 # The base URL of console application api server, refers to the Console base URL of WEB service if console domain is
 # different from api or web app domain.
 # example: http://cloud.dify.ai
-CONSOLE_API_URL: {{ .Values.api.url.consoleApi}}
+CONSOLE_API_URL: {{ .Values.api.url.consoleApi }}
 # The URL for Web APP api server, refers to the Web App base URL of WEB service if web app domain is different from
 # console or api domain.
 # example: http://udify.app

--- a/charts/dify/templates/config.tpl
+++ b/charts/dify/templates/config.tpl
@@ -24,7 +24,7 @@ APP_WEB_URL: {{ .Values.api.url.appWeb | quote }}
 # File preview or download Url prefix.
 # used to display File preview or download Url to the front-end or as Multi-model inputs;
 # Url is signed and has expiration time.
-FILES_URL: {{ .Values.api.url.files }}
+FILES_URL: {{ .Values.api.url.files | quote }}
 # When enabled, migrations will be executed prior to application startup and the application will start after the migrations have completed.
 MIGRATION_ENABLED: {{ .Values.api.migration | toString | quote }}
 
@@ -219,7 +219,7 @@ MILVUS_USER: {{ .Values.externalMilvus.user }}
 # The milvus password.
 MILVUS_PASSWORD: {{ .Values.externalMilvus.password }}
 # The milvus tls switch.
-MILVUS_SECURE: {{ .Values.externalMilvus.useTLS | toString }}
+MILVUS_SECURE: {{ .Values.externalMilvus.useTLS | toString | quote }}
 {{- else if .Values.weaviate.enabled }}
 # The type of vector store to use. Supported values are `weaviate`, `qdrant`, `milvus`.
 VECTOR_STORE: weaviate

--- a/charts/dify/templates/web-config.yaml
+++ b/charts/dify/templates/web-config.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "dify.web.fullname" . }}
+data:
+  {{- include "dify.web.config" . | nindent 2 }}

--- a/charts/dify/templates/web-deployment.yaml
+++ b/charts/dify/templates/web-deployment.yaml
@@ -50,6 +50,9 @@ spec:
         {{- if .Values.web.extraEnv }}
           {{- toYaml .Values.web.extraEnv | nindent 8 }}
         {{- end }}
+        envFrom:
+          - configMapRef:
+              name: {{ template "dify.web.fullname" . }}
         ports:
           - name: web
             containerPort: 3000

--- a/charts/dify/values.yaml
+++ b/charts/dify/values.yaml
@@ -168,16 +168,6 @@ web:
   # Apply your own Environment Variables if necessary
   - name: EDITION
     value: "SELF_HOSTED"
-    # The base URL of console application api server, refers to the Console base URL of WEB service if console domain is
-    # different from api or web app domain.
-    # example: http://cloud.dify.ai
-  - name: CONSOLE_API_URL
-    value: ''
-    # The URL for Web APP api server, refers to the Web App base URL of WEB service if web app domain is different from
-    # console or api domain.
-    # example: http://udify.app
-  - name: APP_API_URL
-    value: ''
   service:
     port: 3000
     annotations: {}

--- a/charts/dify/values.yaml
+++ b/charts/dify/values.yaml
@@ -5,7 +5,7 @@
 image:
   api:
     repository: langgenius/dify-api
-    tag: 0.3.8
+    tag: 0.4.9
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -15,7 +15,7 @@ image:
     #   - myRegistryKeySecretName
   web:    
     repository: langgenius/dify-web
-    tag: 0.3.8
+    tag: 0.4.9
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -56,18 +56,24 @@ api:
     labels: {}
     clusterIP: ""
   url:
-    # The base URL of console application, refers to the Console base URL of WEB service if console domain is
-    # different from api or web app domain.
-    # example: http://cloud.dify.ai
-    console: ''
-    # The URL for Service API endpoints，refers to the base URL of the current API service if api domain is
-    # different from console domain.
-    # example: http://api.dify.ai
-    api: ''
-    # The URL for Web APP, refers to the Web App base URL of WEB service if web app domain is different from
-    # console or api domain.
-    # example: http://udify.app
-    app: ''
+    # The backend URL of the console API, used to concatenate the authorization callback.
+    # If empty, it is the same domain. Example: https://api.console.dify.ai
+    consoleApi: ""
+    # The front-end URL of the console web, used to concatenate some front-end addresses and for CORS configuration use.
+    # If empty, it is the same domain. Example: https://console.dify.ai
+    consoleWeb: ""
+    # Service API Url, used to display Service API Base Url to the front-end.
+    # If empty, it is the same domain. Example: https://api.dify.ai
+    serviceApi: ""
+    # WebApp API backend Url, used to declare the back-end URL for the front-end API.
+    # If empty, it is the same domain. Example: https://app.dify.ai
+    appApi: ""
+    # WebApp Url, used to display WebAPP API Base Url to the front-end. If empty, it is the same domain. Example: https://api.app.dify.ai
+    appWeb: ""
+    # File preview or download URL prefix, used to display the file preview
+    # or download URL to the front-end or as a multi-modal model input;
+    # In order to prevent others from forging, the image preview URL is signed and has a 5-minute expiration time.
+    files: ""
   # When enabled, migrations will be executed prior to application startup and the application will start after the migrations have completed.
   migration: true
   # A secret key that is used for securely signing the session cookie and encrypting sensitive information on the database. You can generate a strong key using `openssl rand -base64 42`.
@@ -2519,3 +2525,15 @@ externalQdrant:
   enabled: false
   endpoint: "https://your-qdrant-cluster-url.qdrant.tech/"
   apiKey: "ak-difyai"
+
+###################################
+# External Milvus
+# - these configs are only used when `externalWeaviate.enabled` is false and `externalQdrant.enabled` is true
+###################################
+externalMilvus:
+  enabled: false
+  host: "your-milvus.domain"
+  port: 19530
+  user: "user"
+  password: "Milvus"
+  useTLS: false

--- a/charts/dify/values.yaml
+++ b/charts/dify/values.yaml
@@ -74,6 +74,13 @@ api:
     # or download URL to the front-end or as a multi-modal model input;
     # In order to prevent others from forging, the image preview URL is signed and has a 5-minute expiration time.
     files: ""
+  mail:
+    type: ''
+    # default enail sender from email address, if not not given specific address
+    defaultSender: 'YOUR EMAIL FROM (eg: no-reply <no-reply@dify.ai>)'
+    # the api-key for resend (https://resend.com)
+    resendApiKey: ''
+    resendApiUrl: https://api.resend.com
   # When enabled, migrations will be executed prior to application startup and the application will start after the migrations have completed.
   migration: true
   # A secret key that is used for securely signing the session cookie and encrypting sensitive information on the database. You can generate a strong key using `openssl rand -base64 42`.


### PR DESCRIPTION
- Add external `milvus` suppport
- Removed deprecated variable since `0.3.8'
  - `CONSOLE_URL`
  - `API_URL`
  - `APP_URL`
- Removed depreciated variable since `0.3.24`
  - `SESSION_TYPE`
  - `SESSION_REDIS_HOST`
  - `SESSION_REDIS_PORT`
  - `SESSION_REDIS_DB`
  - `SESSION_REDIS_USERNAME`
  - `SESSION_REDIS_PASSWORD`
  - `SESSION_REDIS_USE_SSL`
- Added mail configuration