### PR TITLE
(feat) Add support for smtp config

### DIFF
--- a/charts/dify/templates/config.tpl
+++ b/charts/dify/templates/config.tpl
@@ -255,7 +255,7 @@ SMTP_SERVER: {{ .Values.api.mail.smtp.server | quote }}
 SMTP_PORT: {{ .Values.api.mail.smtp.port | quote }}
 SMTP_USERNAME: {{ .Values.api.mail.smtp.username | quote }}
 SMTP_PASSWORD: {{ .Values.api.mail.smtp.password | quote }}
-SMTP_USE_TLS: {{ .Values.api.mail.smtp.useTLS | quote }}
+SMTP_USE_TLS: {{ .Values.api.mail.smtp.useTLS | toString | quote }}
 {{- end }}
 {{- end }}
 

--- a/charts/dify/templates/config.tpl
+++ b/charts/dify/templates/config.tpl
@@ -241,13 +241,22 @@ WEAVIATE_API_KEY: {{ first .Values.weaviate.authentication.apikey.allowed_keys }
 {{- end }}
 
 {{- define "dify.mail.config" -}}
-# Mail configuration, support: resend
+{{- if eq .Values.api.mail.type "resend" }}
+# Mail configuration for resend
 MAIL_TYPE: {{ .Values.api.mail.type | quote }}
-# default send from email address, if not specified
 MAIL_DEFAULT_SEND_FROM: {{ .Values.api.mail.defaultSender | quote }}
-# the api-key for resend (https://resend.com)
 RESEND_API_KEY: {{ .Values.api.mail.resendApiKey | quote }}
 RESEND_API_URL: {{ .Values.api.mail.resendApiUrl | quote }}
+{{- else if eq .Values.api.mail.type "smtp" }}
+# Mail configuration for SMTP
+MAIL_TYPE: {{ .Values.api.mail.type | quote }}
+MAIL_DEFAULT_SEND_FROM: {{ .Values.api.mail.defaultSender | quote }}
+SMTP_SERVER: {{ .Values.api.mail.smtpServer | quote }}
+SMTP_PORT: {{ .Values.api.mail.smtpPort | quote }}
+SMTP_USERNAME: {{ .Values.api.mail.smtpUsername | quote }}
+SMTP_PASSWORD: {{ .Values.api.mail.smtpPassword | quote }}
+SMTP_USE_TLS: {{ .Values.api.mail.smtpUseTLS | quote }}
+{{- end }}
 {{- end }}
 
 {{- define "dify.nginx.config.proxy" }}

--- a/charts/dify/templates/config.tpl
+++ b/charts/dify/templates/config.tpl
@@ -245,17 +245,17 @@ WEAVIATE_API_KEY: {{ first .Values.weaviate.authentication.apikey.allowed_keys }
 # Mail configuration for resend
 MAIL_TYPE: {{ .Values.api.mail.type | quote }}
 MAIL_DEFAULT_SEND_FROM: {{ .Values.api.mail.defaultSender | quote }}
-RESEND_API_KEY: {{ .Values.api.mail.resendApiKey | quote }}
-RESEND_API_URL: {{ .Values.api.mail.resendApiUrl | quote }}
+RESEND_API_KEY: {{ .Values.api.mail.resend.apiKey | quote }}
+RESEND_API_URL: {{ .Values.api.mail.resend.apiUrl | quote }}
 {{- else if eq .Values.api.mail.type "smtp" }}
 # Mail configuration for SMTP
 MAIL_TYPE: {{ .Values.api.mail.type | quote }}
 MAIL_DEFAULT_SEND_FROM: {{ .Values.api.mail.defaultSender | quote }}
-SMTP_SERVER: {{ .Values.api.mail.smtpServer | quote }}
-SMTP_PORT: {{ .Values.api.mail.smtpPort | quote }}
-SMTP_USERNAME: {{ .Values.api.mail.smtpUsername | quote }}
-SMTP_PASSWORD: {{ .Values.api.mail.smtpPassword | quote }}
-SMTP_USE_TLS: {{ .Values.api.mail.smtpUseTLS | quote }}
+SMTP_SERVER: {{ .Values.api.mail.smtp.server | quote }}
+SMTP_PORT: {{ .Values.api.mail.smtp.port | quote }}
+SMTP_USERNAME: {{ .Values.api.mail.smtp.username | quote }}
+SMTP_PASSWORD: {{ .Values.api.mail.smtp.password | quote }}
+SMTP_USE_TLS: {{ .Values.api.mail.smtp.useTLS | quote }}
 {{- end }}
 {{- end }}
 

--- a/charts/dify/values.yaml
+++ b/charts/dify/values.yaml
@@ -91,7 +91,7 @@ api:
       port: 587
       username: "YOUR EMAIL"
       password: "YOUR EMAIL PASSWORD"
-      useTLS: "true"
+      useTLS: true
   # When enabled, migrations will be executed prior to application startup and the application will start after the migrations have completed.
   migration: true
   # A secret key that is used for securely signing the session cookie and encrypting sensitive information on the database. You can generate a strong key using `openssl rand -base64 42`.

--- a/charts/dify/values.yaml
+++ b/charts/dify/values.yaml
@@ -76,12 +76,22 @@ api:
     # In order to prevent others from forging, the image preview URL is signed and has a 5-minute expiration time.
     files: ""
   mail:
-    type: ''
-    # default enail sender from email address, if not not given specific address
+    # default email sender from email address, if not not given specific address
     defaultSender: 'YOUR EMAIL FROM (eg: no-reply <no-reply@dify.ai>)'
-    # the api-key for resend (https://resend.com)
-    resendApiKey: ''
-    resendApiUrl: https://api.resend.com
+    # Mail type, supported values are `smtp`, `resend` https://docs.dify.ai/getting-started/install-self-hosted/environments#mail-related-configuration
+    type: "resend"
+    resend:
+      # Resend API Key
+      apiKey: "xxxx"
+      # Resend API URL
+      apiUrl: https://api.resend.com
+    # SMTP Configuration
+    smtp:
+      server: "smtp.server.com"
+      port: 587
+      username: "YOUR EMAIL"
+      password: "YOUR EMAIL PASSWORD"
+      useTLS: "true"
   # When enabled, migrations will be executed prior to application startup and the application will start after the migrations have completed.
   migration: true
   # A secret key that is used for securely signing the session cookie and encrypting sensitive information on the database. You can generate a strong key using `openssl rand -base64 42`.


### PR DESCRIPTION
## Add Support for SMTP config

If api.mail.type eq `smtp`, it'll allow the definition of smtp config env vars.

https://docs.dify.ai/getting-started/install-self-hosted/environments#mail-related-configuration