### PR TITLE
(fix) Add CONSOLE_WEB_URL to web and worker containers

### DIFF
--- a/charts/dify/templates/config.tpl
+++ b/charts/dify/templates/config.tpl
@@ -71,6 +71,10 @@ SENTRY_PROFILES_SAMPLE_RATE: "1.0"
 # Startup mode, 'worker' starts the Celery worker for processing the queue.
 MODE: worker
 
+# The base URL of console application web frontend, refers to the Console base URL of WEB service if console domain is
+# different from api or web app domain.
+# example: http://cloud.dify.ai
+CONSOLE_WEB_URL: {{ .Values.api.url.consoleWeb | quote }}
 # --- All the configurations below are the same as those in the 'api' service. ---
 
 # The log level for the application. Supported values are `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`

--- a/charts/dify/templates/config.tpl
+++ b/charts/dify/templates/config.tpl
@@ -94,6 +94,10 @@ SECRET_KEY: {{ .Values.api.secretKey }}
 {{- end }}
 
 {{- define "dify.web.config" -}}
+# The base URL of console application web frontend, refers to the Console base URL of WEB service if console domain is
+# different from api or web app domain.
+# example: http://cloud.dify.ai
+CONSOLE_WEB_URL: {{ .Values.api.url.consoleWeb | quote }}
 # The base URL of console application api server, refers to the Console base URL of WEB service if console domain is
 # different from api or web app domain.
 # example: http://cloud.dify.ai

--- a/charts/dify/templates/config.tpl
+++ b/charts/dify/templates/config.tpl
@@ -98,10 +98,6 @@ SECRET_KEY: {{ .Values.api.secretKey }}
 {{- end }}
 
 {{- define "dify.web.config" -}}
-# The base URL of console application web frontend, refers to the Console base URL of WEB service if console domain is
-# different from api or web app domain.
-# example: http://cloud.dify.ai
-CONSOLE_WEB_URL: {{ .Values.api.url.consoleWeb | quote }}
 # The base URL of console application api server, refers to the Console base URL of WEB service if console domain is
 # different from api or web app domain.
 # example: http://cloud.dify.ai


### PR DESCRIPTION
This env var is also required in the web container when sending emails:

https://github.com/langgenius/dify/blob/94d04934b3aa943fce8ad9dfc5c9982e1375bab5/api/tasks/mail_invite_member_task.py#L32C42-L32C57