### PR TITLE
Fix Volume Mount Error

### DIFF
--- a/charts/dify/templates/api-deployment.yaml
+++ b/charts/dify/templates/api-deployment.yaml
@@ -1,4 +1,5 @@
 {{- if and .Values.api.enabled}}
+{{- $usePvc := not (or .Values.externalS3.enabled .Values.externalAzureBlobStorage.enabled) -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -69,7 +70,7 @@ spec:
         resources:
           {{- toYaml .Values.api.resources | nindent 12 }}
         volumeMounts:
-        {{- if not .Values.externalS3.enabled }}
+        {{- if $usePvc }}
         - name: app-data
           mountPath: {{ .Values.api.persistence.mountPath | quote }}
           subPath: {{ .Values.api.persistence.persistentVolumeClaim.subPath | default "" }}
@@ -99,7 +100,7 @@ spec:
 {{ toYaml .Values.api.tolerations | indent 8 }}
     {{- end }}
       volumes:
-      {{- if not (or .Values.externalS3.enabled .Values.externalAzureBlobStorage.enabled) }}
+      {{- if $usePvc }}
       - name: app-data
         persistentVolumeClaim:
           claimName: {{ .Values.api.persistence.persistentVolumeClaim.existingClaim | default (printf "%s" (include "dify.fullname" . | trunc 58)) }}

--- a/charts/dify/templates/worker-deployment.yaml
+++ b/charts/dify/templates/worker-deployment.yaml
@@ -1,4 +1,5 @@
 {{- if and .Values.worker.enabled}}
+{{- $usePvc := not (or .Values.externalS3.enabled .Values.externalAzureBlobStorage.enabled) -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -58,7 +59,7 @@ spec:
         resources:
           {{- toYaml .Values.worker.resources | nindent 12 }}
         volumeMounts:
-        {{- if not .Values.externalS3.enabled }}
+        {{- if $usePvc }}
         - name: app-data
           mountPath: {{ .Values.api.persistence.mountPath | quote }}
           subPath: {{ .Values.api.persistence.persistentVolumeClaim.subPath | default "" }}
@@ -88,7 +89,7 @@ spec:
 {{ toYaml .Values.worker.tolerations | indent 8 }}
     {{- end }}
       volumes:
-      {{- if not (or .Values.externalS3.enabled .Values.externalAzureBlobStorage.enabled) }}
+      {{- if $usePvc }}
       - name: app-data
         persistentVolumeClaim:
           claimName: {{ .Values.api.persistence.persistentVolumeClaim.existingClaim | default (printf "%s" (include "dify.fullname" . | trunc 58)) }}


### PR DESCRIPTION
Fix volume mount error in `api` and `worker` in case `.Values.externalAzureBlobStorage.enabled=true` and `.Values.externalS3.enabled=false`
Identified in https://github.com/BorisPolonsky/dify-helm/issues/68.