### PR TITLE
Explicitly Include Affinity & Toleration Options in PostgresSQL

### DIFF
--- a/charts/dify/values.yaml
+++ b/charts/dify/values.yaml
@@ -286,10 +286,18 @@ postgresql:
       accessModes:
         - ReadWriteOnce
       size: 8Gi
-    # Set, tolerations for postgresql-master pods
-    tolerations: []
-    # Set, affinity for postgresql-master pods
+
+    ## @param primary.affinity Affinity for PostgreSQL primary pods assignment
+    ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+    ## Note: primary.podAffinityPreset, primary.podAntiAffinityPreset, and primary.nodeAffinityPreset will be ignored when it's set
+    ##
     affinity: {}
+
+    ## @param primary.tolerations Tolerations for PostgreSQL primary pods assignment
+    ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+    ##
+    tolerations: []
+
   ## @section PostgreSQL read only replica parameters (only used when `architecture` is set to `replication`)
   ##
   readReplicas:
@@ -304,10 +312,17 @@ postgresql:
       accessModes:
         - ReadWriteOnce
       size: 8Gi
-    # Set, tolerations for postgresql-replicas pods
-    tolerations: []
-    # Set, affinity for postgresql-replicas pods
+
+    ## @param readReplicas.affinity Affinity for PostgreSQL read only pods assignment
+    ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+    ## Note: primary.podAffinityPreset, primary.podAntiAffinityPreset, and primary.nodeAffinityPreset will be ignored when it's set
+    ##
     affinity: {}
+
+    ## @param primary.tolerations Tolerations for PostgreSQL primary pods assignment
+    ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+    ##
+    tolerations: []
 
 
 weaviate:

--- a/charts/dify/values.yaml
+++ b/charts/dify/values.yaml
@@ -319,7 +319,7 @@ postgresql:
     ##
     affinity: {}
 
-    ## @param primary.tolerations Tolerations for PostgreSQL primary pods assignment
+    ## @param readReplicas.tolerations Tolerations for PostgreSQL read only pods assignment
     ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
     ##
     tolerations: []

--- a/charts/dify/values.yaml
+++ b/charts/dify/values.yaml
@@ -286,7 +286,10 @@ postgresql:
       accessModes:
         - ReadWriteOnce
       size: 8Gi
-
+    # Set, tolerations for postgresql-master pods
+    tolerations: []
+    # Set, affinity for postgresql-master pods
+    affinity: {}
   ## @section PostgreSQL read only replica parameters (only used when `architecture` is set to `replication`)
   ##
   readReplicas:
@@ -301,6 +304,10 @@ postgresql:
       accessModes:
         - ReadWriteOnce
       size: 8Gi
+    # Set, tolerations for postgresql-replicas pods
+    tolerations: []
+    # Set, affinity for postgresql-replicas pods
+    affinity: {}
 
 
 weaviate:


### PR DESCRIPTION
Thanks for the wonderful helm solution so that anyone can deploy Dify in Kubernetes. That being said I have identified an issue where the repository lacked example values for tolerations and affinity for the Postgres (master & replicas) deployment. This PR includes an updated values.yaml file with a commented example showcasing how to configure these settings for the Postgres database. Best
Shomu