### PR TITLE
Dify 0.6.11 compatibility update

### DIFF
--- a/charts/dify/templates/_helpers.tpl
+++ b/charts/dify/templates/_helpers.tpl
@@ -56,6 +56,14 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{/*
+Create a default fully qualified web name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "dify.ssrfProxy.fullname" -}}
+{{ template "dify.fullname" . }}-ssrf-proxy
+{{- end -}}
+
+{{/*
 Create a default fully qualified nginx name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}

--- a/charts/dify/templates/config.tpl
+++ b/charts/dify/templates/config.tpl
@@ -63,7 +63,11 @@ SENTRY_DSN: ''
 SENTRY_TRACES_SAMPLE_RATE: "1.0"
 # The sample rate for Sentry profiles. Default: `1.0`
 SENTRY_PROFILES_SAMPLE_RATE: "1.0"
-{{ include "dify.sandbox.config" . }}
+
+{{- if .Values.sandbox.enabled }}
+CODE_EXECUTION_ENDPOINT: http://{{ template "dify.sandbox.fullname" .}}:{{ .Values.sandbox.service.port }}
+{{- end }}
+
 {{- if .Values.ssrfProxy.enabled }}
 HTTP_PROXY: http://{{ template "dify.ssrfProxy.fullname" .}}:{{ .Values.ssrfProxy.service.port }}
 HTTPS_PROXY: http://{{ template "dify.ssrfProxy.fullname" .}}:{{ .Values.ssrfProxy.service.port }}
@@ -287,7 +291,12 @@ SMTP_USE_TLS: {{ .Values.api.mail.smtp.useTLS | toString | quote }}
 {{- end }}
 
 {{- define "dify.sandbox.config" -}}
-CODE_EXECUTION_ENDPOINT: http://{{ template "dify.sandbox.fullname" .}}:{{ .Values.sandbox.service.port }}
+GIN_MODE: release
+SANDBOX_PORT: '8194'
+{{- if .Values.ssrfProxy.enabled }}
+HTTP_PROXY: http://{{ template "dify.ssrfProxy.fullname" .}}:{{ .Values.ssrfProxy.service.port }}
+HTTPS_PROXY: http://{{ template "dify.ssrfProxy.fullname" .}}:{{ .Values.ssrfProxy.service.port }}
+{{- end }}
 {{- end }}
 
 {{- define "dify.nginx.config.proxy" }}

--- a/charts/dify/templates/config.tpl
+++ b/charts/dify/templates/config.tpl
@@ -64,6 +64,10 @@ SENTRY_TRACES_SAMPLE_RATE: "1.0"
 # The sample rate for Sentry profiles. Default: `1.0`
 SENTRY_PROFILES_SAMPLE_RATE: "1.0"
 {{ include "dify.sandbox.config" . }}
+{{- if .Values.ssrfProxy.enabled }}
+HTTP_PROXY: http://{{ template "dify.ssrfProxy.fullname" .}}:{{ .Values.ssrfProxy.service.port }}
+HTTPS_PROXY: http://{{ template "dify.ssrfProxy.fullname" .}}:{{ .Values.ssrfProxy.service.port }}
+{{- end }}
 {{- end }}
 
 {{- define "dify.worker.config" -}}

--- a/charts/dify/templates/config.tpl
+++ b/charts/dify/templates/config.tpl
@@ -69,8 +69,8 @@ CODE_EXECUTION_ENDPOINT: http://{{ template "dify.sandbox.fullname" .}}:{{ .Valu
 {{- end }}
 
 {{- if .Values.ssrfProxy.enabled }}
-HTTP_PROXY: http://{{ template "dify.ssrfProxy.fullname" .}}:{{ .Values.ssrfProxy.service.port }}
-HTTPS_PROXY: http://{{ template "dify.ssrfProxy.fullname" .}}:{{ .Values.ssrfProxy.service.port }}
+SSRF_PROXY_HTTP_URL: http://{{ template "dify.ssrfProxy.fullname" .}}:{{ .Values.ssrfProxy.service.port }}
+SSRF_PROXY_HTTPS_URL: http://{{ template "dify.ssrfProxy.fullname" .}}:{{ .Values.ssrfProxy.service.port }}
 {{- end }}
 {{- end }}
 

--- a/charts/dify/templates/config.tpl
+++ b/charts/dify/templates/config.tpl
@@ -236,7 +236,11 @@ QDRANT_URL: {{ .Values.externalQdrant.endpoint }}
 # The Qdrant API key.
 # QDRANT_API_KEY: {{ .Values.externalQdrant.apiKey }}
 # The Qdrant clinet timeout setting.
-QDRANT_CLIENT_TIMEOUT: "20"
+QDRANT_CLIENT_TIMEOUT: {{ .Values.externalQdrant.timeout | quote }}
+# The Qdrant client enable gRPC mode.
+QDRANT_GRPC_ENABLED: {{ .Values.externalQdrant.grpc.enabled | toString | quote }}
+# The Qdrant server gRPC mode PORT.
+QDRANT_GRPC_PORT: {{ .Values.externalQdrant.grpc.port | quote }}
 # The DSN for Sentry error reporting. If not set, Sentry error reporting will be disabled.
 {{- else if .Values.externalMilvus.enabled}}
 # Milvus configuration Only available when VECTOR_STORE is `milvus`.

--- a/charts/dify/templates/config.tpl
+++ b/charts/dify/templates/config.tpl
@@ -147,7 +147,7 @@ DB_DATABASE: {{ .Values.postgresql.global.postgresql.auth.database }}
 
 {{- define "dify.storage.config" -}}
 {{- if .Values.externalS3.enabled }}
-# The type of storage to use for storing user files. Supported values are `local` and `s3` and `azure-blob`, Default: `local`
+# The type of storage to use for storing user files. Supported values are `local`, `s3`, `azure-blob` and `aliyun-oss`, Default: `local`
 STORAGE_TYPE: s3
 # The S3 storage configurations, only available when STORAGE_TYPE is `s3`.
 S3_ENDPOINT: {{ .Values.externalS3.endpoint }}
@@ -155,8 +155,16 @@ S3_BUCKET_NAME: {{ .Values.externalS3.bucketName }}
 # S3_ACCESS_KEY: {{ .Values.externalS3.accessKey }}
 # S3_SECRET_KEY: {{ .Values.externalS3.secretKey }}
 S3_REGION: 'us-east-1'
+{{- else if .Values.externalAzureBlobStorage.enabled }}
+# The type of storage to use for storing user files. Supported values are `local`, `s3`, `azure-blob` and `aliyun-oss`, Default: `local`
+STORAGE_TYPE: azure-blob
+# The Azure Blob storage configurations, only available when STORAGE_TYPE is `azure-blob`.
+AZURE_BLOB_ACCOUNT_NAME: {{ .Values.externalAzureBlobStorage.account | quote }}
+# AZURE_BLOB_ACCOUNT_KEY: {{ .Values.externalAzureBlobStorage.key | quote }}
+AZURE_BLOB_CONTAINER_NAME: {{ .Values.externalAzureBlobStorage.container | quote }}
+AZURE_BLOB_ACCOUNT_URL: {{ .Values.externalAzureBlobStorage.url | quote }}
 {{- else if .Values.externalOSS.enabled }}
-# The type of storage to use for storing user files. Supported values are `local` and `s3` and `azure-blob`, Default: `local`
+# The type of storage to use for storing user files. Supported values are `local`, `s3`, `azure-blob` and `aliyun-oss`, Default: `local`
 STORAGE_TYPE: aliyun-oss
 # The OSS storage configurations, only available when STORAGE_TYPE is `aliyun-oss`.
 ALIYUN_OSS_ENDPOINT: {{ .Values.externalOSS.endpoint }}
@@ -165,14 +173,6 @@ ALIYUN_OSS_BUCKET_NAME: {{ .Values.externalOSS.bucketName }}
 # ALIYUN_OSS_SECRET_KEY: {{ .Values.externalOSS.secretKey }}
 ALIYUN_OSS_REGION: {{ .Values.externalOSS.region }}
 ALIYUN_OSS_AUTH_VERSION: {{ .Values.externalOSS.authVersion }}
-{{- else if .Values.externalAzureBlobStorage.enabled }}
-STORAGE_TYPE: azure-blob
-# The type of storage to use for storing user files. Supported values are `local` and `s3` and `azure-blob`, Default: `local`
-# The Azure Blob storage configurations, only available when STORAGE_TYPE is `azure-blob`.
-AZURE_BLOB_ACCOUNT_NAME: {{ .Values.externalAzureBlobStorage.account | quote }}
-# AZURE_BLOB_ACCOUNT_KEY: {{ .Values.externalAzureBlobStorage.key | quote }}
-AZURE_BLOB_CONTAINER_NAME: {{ .Values.externalAzureBlobStorage.container | quote }}
-AZURE_BLOB_ACCOUNT_URL: {{ .Values.externalAzureBlobStorage.url | quote }}
 {{- else }}
 # The type of storage to use for storing user files. Supported values are `local` and `s3` and `azure-blob`, Default: `local`
 STORAGE_TYPE: local

--- a/charts/dify/templates/config.tpl
+++ b/charts/dify/templates/config.tpl
@@ -242,14 +242,6 @@ QDRANT_GRPC_ENABLED: {{ .Values.externalQdrant.grpc.enabled | toString | quote }
 # The Qdrant server gRPC mode PORT.
 QDRANT_GRPC_PORT: {{ .Values.externalQdrant.grpc.port | quote }}
 # The DSN for Sentry error reporting. If not set, Sentry error reporting will be disabled.
-{{- else if .Values.externalPgvector.enabled}}
-# Pgvector configuration Only available when VECTOR_STORE is `pgvector`.
-VECTOR_STORE: pgvector
-PGVECTOR_HOST: {{ .Values.externalPgvector.address }}
-PGVECTOR_PORT: {{ .Values.externalPgvector.port | toString | quote }}
-PGVECTOR_DATABASE: {{ .Values.externalPgvector.dbName }}
-# DB_USERNAME: {{ .Values.externalPgvector.username }}
-# DB_PASSWORD: {{ .Values.externalPgvector.password }}
 {{- else if .Values.externalMilvus.enabled}}
 # Milvus configuration Only available when VECTOR_STORE is `milvus`.
 VECTOR_STORE: milvus
@@ -263,6 +255,14 @@ MILVUS_PORT: {{ .Values.externalMilvus.port | toString | quote }}
 # MILVUS_PASSWORD: {{ .Values.externalMilvus.password | quote }}
 # The milvus tls switch.
 MILVUS_SECURE: {{ .Values.externalMilvus.useTLS | toString | quote }}
+{{- else if .Values.externalPgvector.enabled}}
+# pgvector configurations, only available when VECTOR_STORE is `pgvecto-rs or pgvector`
+VECTOR_STORE: pgvector
+PGVECTOR_HOST: {{ .Values.externalPgvector.address }}
+PGVECTOR_PORT: {{ .Values.externalPgvector.port | toString | quote }}
+PGVECTOR_DATABASE: {{ .Values.externalPgvector.dbName }}
+# DB_USERNAME: {{ .Values.externalPgvector.username }}
+# DB_PASSWORD: {{ .Values.externalPgvector.password }}
 {{- else if .Values.weaviate.enabled }}
 # The type of vector store to use. Supported values are `weaviate`, `qdrant`, `milvus`.
 VECTOR_STORE: weaviate

--- a/charts/dify/templates/config.tpl
+++ b/charts/dify/templates/config.tpl
@@ -366,3 +366,62 @@ server {
     }
 }
 {{- end }}
+
+{{- define "dify.ssrfProxy.config.squid" }}
+acl localnet src 0.0.0.1-0.255.255.255	# RFC 1122 "this" network (LAN)
+acl localnet src 10.0.0.0/8		# RFC 1918 local private network (LAN)
+acl localnet src 100.64.0.0/10		# RFC 6598 shared address space (CGN)
+acl localnet src 169.254.0.0/16 	# RFC 3927 link-local (directly plugged) machines
+acl localnet src 172.16.0.0/12		# RFC 1918 local private network (LAN)
+acl localnet src 192.168.0.0/16		# RFC 1918 local private network (LAN)
+acl localnet src fc00::/7       	# RFC 4193 local private network range
+acl localnet src fe80::/10      	# RFC 4291 link-local (directly plugged) machines
+acl SSL_ports port 443
+acl Safe_ports port 80		# http
+acl Safe_ports port 21		# ftp
+acl Safe_ports port 443		# https
+acl Safe_ports port 70		# gopher
+acl Safe_ports port 210		# wais
+acl Safe_ports port 1025-65535	# unregistered ports
+acl Safe_ports port 280		# http-mgmt
+acl Safe_ports port 488		# gss-http
+acl Safe_ports port 591		# filemaker
+acl Safe_ports port 777		# multiling http
+acl CONNECT method CONNECT
+http_access deny !Safe_ports
+http_access deny CONNECT !SSL_ports
+http_access allow localhost manager
+http_access deny manager
+http_access allow localhost
+include /etc/squid/conf.d/*.conf
+http_access deny all
+
+################################## Proxy Server ################################
+http_port 3128
+coredump_dir /var/spool/squid
+refresh_pattern ^ftp:		1440	20%	10080
+refresh_pattern ^gopher:	1440	0%	1440
+refresh_pattern -i (/cgi-bin/|\?) 0	0%	0
+refresh_pattern \/(Packages|Sources)(|\.bz2|\.gz|\.xz)$ 0 0% 0 refresh-ims
+refresh_pattern \/Release(|\.gpg)$ 0 0% 0 refresh-ims
+refresh_pattern \/InRelease$ 0 0% 0 refresh-ims
+refresh_pattern \/(Translation-.*)(|\.bz2|\.gz|\.xz)$ 0 0% 0 refresh-ims
+refresh_pattern .		0	20%	4320
+
+# upstream proxy, set to your own upstream proxy IP to avoid SSRF attacks
+# cache_peer 172.1.1.1 parent 3128 0 no-query no-digest no-netdb-exchange default
+
+
+################################## Reverse Proxy To Sandbox ################################
+http_port {{ .Values.sandbox.service.port }} accel vhost
+cache_peer {{ template "dify.sandbox.fullname" .}} parent {{ .Values.sandbox.service.port }} 0 no-query originserver
+acl src_all src all
+http_access allow src_all
+
+{{/*Dump logs to stdout only when log persistence is not enabled*/}}
+{{- if not .Values.ssrfProxy.log.persistence.enabled }}
+cache_log none
+access_log none
+cache_store_log none
+{{- end }}
+{{- end }}

--- a/charts/dify/templates/config.tpl
+++ b/charts/dify/templates/config.tpl
@@ -286,7 +286,8 @@ SMTP_SERVER: {{ .Values.api.mail.smtp.server | quote }}
 SMTP_PORT: {{ .Values.api.mail.smtp.port | quote }}
 # SMTP_USERNAME: {{ .Values.api.mail.smtp.username | quote }}
 # SMTP_PASSWORD: {{ .Values.api.mail.smtp.password | quote }}
-SMTP_USE_TLS: {{ .Values.api.mail.smtp.useTLS | toString | quote }}
+SMTP_USE_TLS: {{ .Values.api.mail.smtp.tls.enabled | toString | quote }}
+SMTP_OPPORTUNISTIC_TLS: {{ .Values.api.mail.smtp.tls.optimistic | toString | quote }}
 {{- end }}
 {{- end }}
 

--- a/charts/dify/templates/credentials.tpl
+++ b/charts/dify/templates/credentials.tpl
@@ -56,12 +56,12 @@ DB_PASSWORD: {{ .password | b64enc | quote }}
 {{- if .Values.externalS3.enabled}}
 S3_ACCESS_KEY: {{ .Values.externalS3.accessKey | b64enc | quote }}
 S3_SECRET_KEY: {{ .Values.externalS3.secretKey | b64enc | quote }}
-{{- else if .Values.externalOSS.enabled }}
-ALIYUN_OSS_ACCESS_KEY: {{ .Values.externalOSS.accessKey | b64enc | quote  }}
-ALIYUN_OSS_SECRET_KEY: {{ .Values.externalOSS.secretKey | b64enc | quote  }}
 {{- else if .Values.externalAzureBlobStorage.enabled }}
 # The Azure Blob storage configurations, only available when STORAGE_TYPE is `azure-blob`.
 AZURE_BLOB_ACCOUNT_KEY: {{ .Values.externalAzureBlobStorage.key | b64enc | quote }}
+{{- else if .Values.externalOSS.enabled }}
+ALIYUN_OSS_ACCESS_KEY: {{ .Values.externalOSS.accessKey | b64enc | quote  }}
+ALIYUN_OSS_SECRET_KEY: {{ .Values.externalOSS.secretKey | b64enc | quote  }}
 {{- else }}
 {{- end }}
 {{- end }}

--- a/charts/dify/templates/credentials.tpl
+++ b/charts/dify/templates/credentials.tpl
@@ -100,14 +100,14 @@ CELERY_BROKER_URL: {{ printf "redis://:%s@%s:%v/1" .auth.password $redisHost .ma
 WEAVIATE_API_KEY: {{ .Values.externalWeaviate.apiKey | b64enc | quote }}
 {{- else if .Values.externalQdrant.enabled }}
 QDRANT_API_KEY: {{ .Values.externalQdrant.apiKey | b64enc | quote }}
-{{- else if .Values.externalPgvector.enabled}}
-PGVECTOR_USER: {{ .Values.externalPgvector.username | b64enc | quote }}
-# The pgvector password.
-PGVECTOR_PASSWORD: {{ .Values.externalPgvector.password | b64enc | quote }}
 {{- else if .Values.externalMilvus.enabled}}
 MILVUS_USER: {{ .Values.externalMilvus.user | b64enc | quote }}
 # The milvus password.
 MILVUS_PASSWORD: {{ .Values.externalMilvus.password | b64enc | quote }}
+{{- else if .Values.externalPgvector.enabled}}
+PGVECTOR_USER: {{ .Values.externalPgvector.username | b64enc | quote }}
+# The pgvector password.
+PGVECTOR_PASSWORD: {{ .Values.externalPgvector.password | b64enc | quote }}
 {{- else if .Values.weaviate.enabled }}
 # The Weaviate API key.
   {{- if .Values.weaviate.authentication.apikey }}

--- a/charts/dify/templates/credentials.tpl
+++ b/charts/dify/templates/credentials.tpl
@@ -1,6 +1,9 @@
 {{- define "dify.api.credentials" -}}
 # A secret key that is used for securely signing the session cookie and encrypting sensitive information on the database. You can generate a strong key using `openssl rand -base64 42`.
 SECRET_KEY: {{ .Values.api.secretKey | b64enc | quote }}
+{{- if .Values.sandbox.enabled }}
+CODE_EXECUTION_API_KEY: {{ .Values.sandbox.auth.apiKey | b64enc | quote }}
+{{- end }}
 {{- include "dify.db.credentials" . }}
 # The configurations of redis connection.
 # It is consistent with the configuration in the 'redis' service below.

--- a/charts/dify/templates/pvc.yaml
+++ b/charts/dify/templates/pvc.yaml
@@ -1,4 +1,4 @@
-{{- if not (or .Values.externalS3.enabled .Values.externalOSS.enabled) }}
+{{- if not (or .Values.externalS3.enabled .Values.externalAzureBlobStorage.enabled .Values.externalOSS.enabled) }}
 {{- $pvc := .Values.api.persistence.persistentVolumeClaim -}}
 {{- if (not $pvc.existingClaim) }}
 apiVersion: v1

--- a/charts/dify/templates/pvc.yaml
+++ b/charts/dify/templates/pvc.yaml
@@ -57,3 +57,34 @@ spec:
     requests:
       storage: {{ $pvc.size }}
 {{- end }}
+
+
+{{- $pvc := .Values.ssrfProxy.log.persistence.persistentVolumeClaim -}}
+{{- if and .Values.ssrfProxy.log.persistence.enabled (not $pvc.existingClaim) }}
+
+---
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ printf "%s-logs" (include "dify.ssrfProxy.fullname" . | trunc 58)}}
+{{- with .Values.ssrfProxy.log.persistence.annotations  }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+  labels:
+{{ include "dify.labels" . | indent 4 }}
+spec:
+  accessModes:
+  - {{ $pvc.accessModes | quote }}
+  {{- if $pvc.storageClass }}
+    {{- if eq "-" $pvc.storageClass }}
+  storageClassName: ""
+    {{- else }}
+  storageClassName: {{ $pvc.storageClass }}
+    {{- end }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ $pvc.size }}
+{{- end }}

--- a/charts/dify/templates/sandbox-config.yaml
+++ b/charts/dify/templates/sandbox-config.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "dify.sandbox.fullname" . }}
+data:
+  {{- include "dify.sandbox.config" . | nindent 2 }}

--- a/charts/dify/templates/sandbox-deployment.yaml
+++ b/charts/dify/templates/sandbox-deployment.yaml
@@ -51,6 +51,8 @@ spec:
           {{- toYaml .Values.sandbox.extraEnv | nindent 8 }}
         {{- end }}
         envFrom:
+        - configMapRef:
+            name: {{ template "dify.sandbox.fullname" . }}
         - secretRef:
             name: {{ template "dify.sandbox.fullname" . }}
         ports:

--- a/charts/dify/templates/ssrf-proxy-configmap.yaml
+++ b/charts/dify/templates/ssrf-proxy-configmap.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.ssrfProxy.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "dify.ssrfProxy.fullname" . }}
+data:
+  squid.conf: |-
+    {{- include "dify.ssrfProxy.config.squid" . | indent 4 }}
+{{- end }}

--- a/charts/dify/templates/ssrf-proxy-deployment.yaml
+++ b/charts/dify/templates/ssrf-proxy-deployment.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.ssrfProxy.enabled}}
+{{- if .Values.ssrfProxy.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -55,10 +55,17 @@ spec:
             containerPort: 3128
             protocol: TCP
         volumeMounts:
-          - mountPath: /var/cache/squid
-            name: squid-cache
-          - mountPath: /var/log/squid
-            name: squid-log
+        - name: squid-conf
+          mountPath: /etc/squid/squid.conf
+          readOnly: true
+          subPath: squid.conf
+        - mountPath: /var/cache/squid
+          name: squid-cache
+        {{- if .Values.ssrfProxy.log.persistence.enabled }}
+        - name: squid-log
+          mountPath: {{ .Values.ssrfProxy.log.persistence.mountPath | quote }}
+          subPath: {{ .Values.ssrfProxy.log.persistence.persistentVolumeClaim.subPath | default "" }}
+        {{- end }}
         resources:
           {{- toYaml .Values.ssrfProxy.resources | nindent 12 }}
         securityContext:
@@ -88,8 +95,15 @@ spec:
 {{ toYaml .Values.ssrfProxy.tolerations | indent 8 }}
     {{- end }}
       volumes:
-        - name: squid-cache
-          emptyDir: {}
-        - name: squid-log
-          emptyDir: {}
+      - name: squid-conf
+        configMap:
+          defaultMode: 420
+          name: {{ template "dify.ssrfProxy.fullname" . }}
+      - name: squid-cache
+        emptyDir: {}
+      {{- if .Values.ssrfProxy.log.persistence.enabled }}
+      - name: squid-log
+        persistentVolumeClaim:
+          claimName: {{ .Values.ssrfProxy.log.persistence.persistentVolumeClaim.existingClaim | default (printf "%s-logs" (include "dify.ssrfProxy.fullname" . | trunc 58)) }}
+      {{- end }}
 {{- end }}

--- a/charts/dify/templates/ssrf-proxy-deployment.yaml
+++ b/charts/dify/templates/ssrf-proxy-deployment.yaml
@@ -59,8 +59,6 @@ spec:
           mountPath: /etc/squid/squid.conf
           readOnly: true
           subPath: squid.conf
-        - mountPath: /var/cache/squid
-          name: squid-cache
         {{- if .Values.ssrfProxy.log.persistence.enabled }}
         - name: squid-log
           mountPath: {{ .Values.ssrfProxy.log.persistence.mountPath | quote }}
@@ -99,8 +97,6 @@ spec:
         configMap:
           defaultMode: 420
           name: {{ template "dify.ssrfProxy.fullname" . }}
-      - name: squid-cache
-        emptyDir: {}
       {{- if .Values.ssrfProxy.log.persistence.enabled }}
       - name: squid-log
         persistentVolumeClaim:

--- a/charts/dify/templates/ssrf-proxy-deployment.yaml
+++ b/charts/dify/templates/ssrf-proxy-deployment.yaml
@@ -1,0 +1,95 @@
+{{- if and .Values.ssrfProxy.enabled}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+{{ include "dify.ud.annotations" . | indent 4 }}
+    descriptions: 'SSRF Proxy'
+  labels:
+{{- include "dify.labels" . | nindent 4 }}
+    component: ssrf-proxy
+    # app: {{ template "dify.ssrfProxy.fullname" . }}
+{{ include "dify.ud.labels" . | indent 4 }}
+  name: {{ template "dify.ssrfProxy.fullname" . }}
+spec:
+  replicas: {{ .Values.ssrfProxy.replicas }}
+  selector:
+    matchLabels:
+{{- include "dify.selectorLabels" . | nindent 6 }}
+      component: ssrf-proxy
+      {{/*
+      # Required labels for istio
+      # app: {{ template "dify.ssrfProxy.fullname" . }}
+      # version: {{ (print "v" .Values.serviceMesh.version) | quote }}
+      */}}
+  template:
+    metadata:
+      annotations:
+{{ include "dify.ud.annotations" . | indent 8 }}
+      labels:
+{{- include "dify.selectorLabels" . | nindent 8 }}
+        component: ssrf-proxy
+        {{/*
+        # Required labels for istio
+        # app: {{ template "dify.ssrfProxy.fullname" . }}
+        # version: {{ (print "v" .Values.serviceMesh.version) | quote }}
+        */}}
+{{ include "dify.ud.labels" . | indent 8 }}
+    spec:
+      {{- if .Values.image.ssrfProxy.pullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.image.ssrfProxy.pullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
+      containers:
+      - image: "{{ .Values.image.ssrfProxy.repository }}:{{ .Values.image.ssrfProxy.tag }}"
+        imagePullPolicy: "{{ .Values.image.ssrfProxy.pullPolicy }}"
+        name: squid
+        env:
+        {{- if .Values.ssrfProxy.extraEnv }}
+          {{- toYaml .Values.ssrfProxy.extraEnv | nindent 8 }}
+        {{- end }}
+        ports:
+          - name: http
+            containerPort: 3128
+            protocol: TCP
+        volumeMounts:
+          - mountPath: /var/cache/squid
+            name: squid-cache
+          - mountPath: /var/log/squid
+            name: squid-log
+        resources:
+          {{- toYaml .Values.ssrfProxy.resources | nindent 12 }}
+        securityContext:
+          allowPrivilegeEscalation: {{ .Values.ssrfProxy.privileged }}
+    {{- if and (.Values.nodeSelector) (not .Values.ssrfProxy.nodeSelector) }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+    {{- end }}
+    {{- if .Values.ssrfProxy.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.ssrfProxy.nodeSelector | indent 8 }}
+    {{- end }}
+    {{- if and (.Values.affinity) (not .Values.ssrfProxy.affinity) }}
+      affinity:
+{{ toYaml .Values.affinity | indent 8 }}
+    {{- end }}
+    {{- if .Values.ssrfProxy.affinity }}
+      affinity:
+{{ toYaml .Values.ssrfProxy.affinity | indent 8 }}
+    {{- end }}
+    {{- if and (.Values.tolerations) (not .Values.ssrfProxy.tolerations) }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
+    {{- end }}
+    {{- if .Values.ssrfProxy.tolerations }}
+      tolerations:
+{{ toYaml .Values.ssrfProxy.tolerations | indent 8 }}
+    {{- end }}
+      volumes:
+        - name: squid-cache
+          emptyDir: {}
+        - name: squid-log
+          emptyDir: {}
+{{- end }}

--- a/charts/dify/templates/ssrf-proxy-svc.yaml
+++ b/charts/dify/templates/ssrf-proxy-svc.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.ssrfProxy.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "dify.ssrfProxy.fullname" . }}
+  labels:
+{{ include "dify.labels" . | indent 4 }}
+{{- if .Values.ssrfProxy.service.labels }}
+{{ toYaml .Values.ssrfProxy.service.labels | indent 4 }}
+{{- end }}
+    component: "ssrf-proxy"
+{{- with .Values.ssrfProxy.service.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+  type: ClusterIP
+  {{- if .Values.ssrfProxy.service.clusterIP }}
+  clusterIP: {{ .Values.ssrfProxy.service.clusterIP }}
+  {{- end }}
+  ports:
+    - name: http-squid
+      port: {{ .Values.ssrfProxy.service.port }}
+      protocol: TCP
+      targetPort: http
+  selector:
+{{ include "dify.selectorLabels" . | indent 4 }}
+    component: "ssrf-proxy"
+{{- end }}

--- a/charts/dify/values.yaml
+++ b/charts/dify/values.yaml
@@ -132,10 +132,12 @@ api:
     # SMTP Configuration
     smtp:
       server: "smtp.server.com"
-      port: 587
+      port: 465
       username: "YOUR EMAIL"
       password: "YOUR EMAIL PASSWORD"
-      useTLS: true
+      tls:
+        enabled: true
+        optimistic: false
   # When enabled, migrations will be executed prior to application startup and the application will start after the migrations have completed.
   migration: true
   # A secret key that is used for securely signing the session cookie and encrypting sensitive information on the database. You can generate a strong key using `openssl rand -base64 42`.

--- a/charts/dify/values.yaml
+++ b/charts/dify/values.yaml
@@ -264,7 +264,7 @@ sandbox:
     false
 
 ssrfProxy:
-  enabled: true
+  enabled: false
   replicas: 1
   resources: {}
   nodeSelector: {}
@@ -279,7 +279,7 @@ ssrfProxy:
       ## If true, create/use a Persistent Volume Claim for log
       ## If false, flush logs to stdout & stderr
       ##
-      enabled: true
+      enabled: false
       mountPath: "/var/log/squid"
       annotations:
         helm.sh/resource-policy: keep

--- a/charts/dify/values.yaml
+++ b/charts/dify/values.yaml
@@ -2700,6 +2700,10 @@ externalQdrant:
   enabled: false
   endpoint: "https://your-qdrant-cluster-url.qdrant.tech/"
   apiKey: "ak-difyai"
+  timeout: 20
+  grpc:
+    enabled: false
+    port: 6334
 
 ###################################
 # External Milvus

--- a/charts/dify/values.yaml
+++ b/charts/dify/values.yaml
@@ -5,7 +5,7 @@
 image:
   api:
     repository: langgenius/dify-api
-    tag: "0.6.9"
+    tag: "0.6.11"
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -15,7 +15,7 @@ image:
     #   - myRegistryKeySecretName
   web:    
     repository: langgenius/dify-web
-    tag: "0.6.9"
+    tag: "0.6.11"
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -25,7 +25,7 @@ image:
     #   - myRegistryKeySecretName
   sandbox:
     repository: langgenius/dify-sandbox
-    tag: "latest"
+    tag: "0.2.1"
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -37,6 +37,16 @@ image:
     repository: nginx
     tag: latest
     pullPolicy: IfNotPresent
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    ##
+    # pullSecrets:
+    #   - myRegistryKeySecretName
+
+  ssrfProxy:
+    image: ubuntu/squid
+    tag: latest
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
     ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
@@ -253,6 +263,23 @@ sandbox:
     apiKey: "dify-sandbox"
   privileged:
     false
+
+ssrfProxy:
+  enabled: true
+  replicas: 1
+  resources: {}
+  nodeSelector: {}
+  affinity: {}
+  tolerations: []
+  extraEnv:
+  # Apply your own Environment Variables if necessary
+  # - name: LANG
+  #   value: "C.UTF-8"
+  service:
+    port: 3128
+    annotations: {}
+    labels: {}
+    clusterIP: ""
 
 postgresql:
   enabled: true

--- a/charts/dify/values.yaml
+++ b/charts/dify/values.yaml
@@ -251,8 +251,6 @@ sandbox:
   # Apply your own Environment Variables if necessary
   # - name: LANG
   #   value: "C.UTF-8"
-  - name: GIN_MODE
-    value: release
   - name: WORKER_TIMEOUT
     value: "15"
   service:

--- a/charts/dify/values.yaml
+++ b/charts/dify/values.yaml
@@ -45,8 +45,9 @@ image:
     #   - myRegistryKeySecretName
 
   ssrfProxy:
-    image: ubuntu/squid
+    repository: ubuntu/squid
     tag: latest
+    pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
     ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/

--- a/charts/dify/values.yaml
+++ b/charts/dify/values.yaml
@@ -276,6 +276,28 @@ ssrfProxy:
   # Apply your own Environment Variables if necessary
   # - name: LANG
   #   value: "C.UTF-8"
+  log:
+    persistence:
+      ## If true, create/use a Persistent Volume Claim for log
+      ## If false, flush logs to stdout & stderr
+      ##
+      enabled: true
+      mountPath: "/var/log/squid"
+      annotations:
+        helm.sh/resource-policy: keep
+      persistentVolumeClaim:
+        existingClaim: ""
+        ## Squid Logs Persistent Volume Storage Class
+        ## If defined, storageClassName: <storageClass>
+        ## If set to "-", storageClassName: "", which disables dynamic provisioning
+        ## If undefined (the default) or set to null, no storageClassName spec is
+        ##   set, choosing the default provisioner.
+        ## ReadWriteMany access mode required for squid
+        ##
+        storageClass:
+        accessModes: ReadWriteMany
+        size: 1Gi
+        subPath: ""
   service:
     port: 3128
     annotations: {}


### PR DESCRIPTION
# Dify 0.6.11 compatibility update
## Update
- Added `ssrf_proxy`
- Fixed `sandbox` authentication and overhauled sandbox configuration definition
- Added `grpc` and `timeout` configuration in `.Values.externalQdrant`
- Resolve `sandbox` compatibility issue by using explicit version tags of  `langgenius/dify-sandbox' instead of `latest` https://github.com/langgenius/dify/issues/5247
## Breaking Change
- Configuration layout and default values of of `SMTP` for `api` is now changed
  - Use port `465` instead `587`
  - `.Values.api.mail.smtp.useTLS` no longer takes effect, use `.Values.api.mail.smtp.tls.enabled` instead.