### PR TITLE
add external milvus database option

### DIFF
--- a/charts/dify/templates/config.tpl
+++ b/charts/dify/templates/config.tpl
@@ -274,6 +274,8 @@ VECTOR_STORE: milvus
 MILVUS_HOST: {{ .Values.externalMilvus.host | quote }}
 # The milvus host.
 MILVUS_PORT: {{ .Values.externalMilvus.port | toString | quote }}
+# The milvus database
+MILVUS_DATABASE: {{ .Values.externalMilvus.database | quote }}
 # The milvus username.
 # MILVUS_USER: {{ .Values.externalMilvus.user | quote }}
 # The milvus password.

--- a/charts/dify/values.yaml
+++ b/charts/dify/values.yaml
@@ -3049,6 +3049,7 @@ externalMilvus:
   enabled: false
   host: "your-milvus.domain"
   port: 19530
+  database: 'default'
   user: "user"
   password: "Milvus"
   useTLS: false


### PR DESCRIPTION
Adds support for specifying a custom Milvus database.

**Problem:**

The current implementation hardcodes the "default" database name for Milvus.  External Milvus instances may require a different database name.

**Solution:**

Introduces the `MILVUS_DATABASE` environment variable to allow users to specify the database to use when connecting to an external Milvus instance.

**Details:**

*   Adds `MILVUS_DATABASE` to `templates/config.tpl`.
*   Adds `externalMilvus.database` option in `values.yaml`

**Usage:**

Set `externalMilvus.database` in your `values.yaml` file to the desired database name.

**Benefits:**

*   Enables Dify to connect to external Milvus instances using custom database names.