### PR TITLE
feat: let nginx proxy marketplace api request

### DIFF
--- a/charts/dify/templates/config.tpl
+++ b/charts/dify/templates/config.tpl
@@ -434,6 +434,15 @@ server {
       include proxy.conf;
     }
 
+    location /marketplace {
+      rewrite ^/marketplace/(.*)$ /$1 break;
+      proxy_ssl_server_name on;
+      proxy_pass https://marketplace.dify.ai;
+      proxy_pass_request_headers off;
+      proxy_set_header Host "marketplace.dify.ai";
+      proxy_set_header Connection "";
+    }
+
     location / {
       proxy_pass http://{{ template "dify.web.fullname" .}}:{{ .Values.web.service.port }};
       include proxy.conf;

--- a/charts/dify/templates/web-deployment.yaml
+++ b/charts/dify/templates/web-deployment.yaml
@@ -86,10 +86,10 @@ spec:
 {{ toYaml .Values.web.containerSecurityContext | indent 10 }}
         {{- end }}
         env:
-          - name: MARKETPLACE_URL
-            value: https://marketplace.dify.ai
-          - name: MARKETPLACE_API_URL
-            value: /marketplace
+        - name: MARKETPLACE_URL
+          value: https://marketplace.dify.ai
+        - name: MARKETPLACE_API_URL
+          value: /marketplace
         {{- if .Values.web.extraEnv }}
           {{- toYaml .Values.web.extraEnv | nindent 8 }}
         {{- end }}

--- a/charts/dify/templates/web-deployment.yaml
+++ b/charts/dify/templates/web-deployment.yaml
@@ -86,6 +86,10 @@ spec:
 {{ toYaml .Values.web.containerSecurityContext | indent 10 }}
         {{- end }}
         env:
+          - name: MARKETPLACE_URL
+            value: https://marketplace.dify.ai
+          - name: MARKETPLACE_API_URL
+            value: /marketplace
         {{- if .Values.web.extraEnv }}
           {{- toYaml .Values.web.extraEnv | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
Since dify 1.0 introduced plugins and a plugin marketplace that fetches data from `marketplace.dify.ai` using fetch in the user's browser, the browser will add the URL of the self-hosted instance in the request `Referer` header, which allows the instance hostname to be reported to a centralized service for potential use for analytics purposes. The component is not open source at this time and does not support self-hosting.

This PR introduces a modification so that nginx in the stack proxies and forwards these requests, and the redundant request header is removed when it proxies.

In addition to this, clicking on the details button on the marketplace page takes you to the `marketplace.dify.ai` site while sending the `Referer` request header, which cannot be resolved unless modifications are made upstream (dify itself) or the entire site is proxied, which doesn't seem to be feasible; the icon address returned by the API is currently using the Cloudflare R2 service, which also send the `Referer` request header, and also cannot be resolved.

Aside from privacy, there are some benefits to this, as requests to marketplace are moved to the server side rather than the browser, which makes it less susceptible to poor network conditions in the browser.

---

I noticed that the `MARKETPLACE_URL` and `MARKETPLACE_API_URL` environment variables are newly added and they are not implemented in this chart for now, so the site would try to request `127.0.0.1:5001`, making the marketplace not work, which the PR corrected by the way.

Ref:
https://github.com/langgenius/dify/blob/43ab7c22a78f4376275510c7178baf17575cdbe1/web/config/index.ts#L32-L35
https://github.com/langgenius/dify/blob/43ab7c22a78f4376275510c7178baf17575cdbe1/web/docker/entrypoint.sh#L19-L20

---

Basically, the best way to do this is not to use the built-in marketplace directly on a self-hosted instance, but to go to marketplace.dify.ai and download the plugin package and install it manually. But this may not be suitable for the widest user.