### PR TITLE
0.23.0 Rlease Candidate 2

### DIFF
--- a/charts/dify/Chart.yaml
+++ b/charts/dify/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.23.0-rc1
+version: 0.23.0-rc2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
- Bump version to `0.23.0-rc2`
- Optionally expose port for plugin installation as a service
- Supply mandatory environment variables for `pluginDaemon` as their default values