### PR TITLE
Bugfix for "Accessing /embed.min.js returns a 404 error"

### DIFF
--- a/charts/dify/templates/config.tpl
+++ b/charts/dify/templates/config.tpl
@@ -440,7 +440,7 @@ server {
       include proxy.conf;
     }
 
-    location /e {
+    location /e/ {
       proxy_pass http://{{ template "dify.pluginDaemon.fullname" .}}:{{ .Values.pluginDaemon.service.ports.daemon }};
       include proxy.conf;
     }


### PR DESCRIPTION
Fixes: https://github.com/langgenius/dify/issues/14797#issuecomment-2694310008

Can confirm it. 