### PR TITLE
fix: The error is caused by too many environment variables. 

### DIFF
--- a/charts/dify/templates/web-deployment.yaml
+++ b/charts/dify/templates/web-deployment.yaml
@@ -98,6 +98,7 @@ spec:
             protocol: TCP
         resources:
           {{- toYaml .Values.web.resources | nindent 12 }}
+        enableServiceLinks: {{ .Values.web.enableServiceLinks }}
     {{- if and (.Values.nodeSelector) (not .Values.web.nodeSelector) }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}

--- a/charts/dify/values.yaml
+++ b/charts/dify/values.yaml
@@ -436,6 +436,7 @@ web:
     ## @param web.serviceAccount.annotations Additional custom annotations for the ServiceAccount
     ##
     annotations: {}
+  enableServiceLinks: false
 
 sandbox:
   enabled: true

--- a/charts/dify/values.yaml
+++ b/charts/dify/values.yaml
@@ -436,6 +436,8 @@ web:
     ## @param web.serviceAccount.annotations Additional custom annotations for the ServiceAccount
     ##
     annotations: {}
+  ## @param web.serviceAccount.enableServiceLinks Disable this feature if additional environment variables would lead to `E2BIG` errors in case frontend were managed by `pm2`
+  ##
   enableServiceLinks: false
 
 sandbox:

--- a/charts/dify/values.yaml
+++ b/charts/dify/values.yaml
@@ -436,7 +436,7 @@ web:
     ## @param web.serviceAccount.annotations Additional custom annotations for the ServiceAccount
     ##
     annotations: {}
-  ## @param web.serviceAccount.enableServiceLinks Disable this feature if additional environment variables would lead to `E2BIG` errors in case frontend were managed by `pm2`
+  ## @param web.enableServiceLinks Disable this feature if additional environment variables would lead to `E2BIG` errors in case frontend were managed by `pm2`
   ##
   enableServiceLinks: false
 


### PR DESCRIPTION
The error is caused by too many environment variables. When starting a container, Kubernetes injects environment variables into it. The more projects in the Kubernetes cluster, the more environment variables are injected. When PM2 starts, it imports system environment variables. If there are too many environment variables, PM2 will throw the error: [PM2][ERROR] Process failed to launch spawn E2BIG.
Add enableServiceLinks: false in the deployment.spec.template.spec section of the Pod to prevent Kubernetes from automatically injecting Service-related information into environment variables.