### PR TITLE
Allow user to substitute object storage (S3 and Tencent COS) for PVC with for `pluginDaemon`

### DIFF
--- a/charts/dify/templates/config.tpl
+++ b/charts/dify/templates/config.tpl
@@ -167,7 +167,7 @@ DB_DATABASE: {{ .Values.postgresql.global.postgresql.auth.database }}
 STORAGE_TYPE: s3
 # The S3 storage configurations, only available when STORAGE_TYPE is `s3`.
 S3_ENDPOINT: {{ .Values.externalS3.endpoint }}
-S3_BUCKET_NAME: {{ .Values.externalS3.bucketName }}
+S3_BUCKET_NAME: {{ .Values.externalS3.bucketName.api }}
 # S3_ACCESS_KEY: {{ .Values.externalS3.accessKey }}
 # S3_SECRET_KEY: {{ .Values.externalS3.secretKey }}
 S3_REGION: {{ .Values.externalS3.region }}
@@ -537,6 +537,7 @@ DB_DATABASE: {{ .Values.externalPostgres.database.pluginDaemon | quote }}
 {{- define "dify.pluginDaemon.config" }}
 {{- include "dify.redis.config" . }}
 {{- include "dify.pluginDaemon.db.config" .}}
+{{- include "dify.pluginDaemon.storage.config" .}}
 SERVER_PORT: "5002"
 PLUGIN_REMOTE_INSTALLING_HOST: "0.0.0.0"
 PLUGIN_REMOTE_INSTALLING_PORT: "5003"
@@ -552,5 +553,18 @@ MARKETPLACE_ENABLED: "true"
 MARKETPLACE_API_URL: {{ .Values.api.url.marketplaceApi | quote }}
 {{- else }}
 MARKETPLACE_ENABLED: "false"
+{{- end }}
+{{- end }}
+
+{{- define "dify.pluginDaemon.storage.config" -}}
+{{- if and .Values.externalS3.enabled .Values.externalS3.bucketName.pluginDaemon }}
+PLUGIN_STORAGE_TYPE: aws_s3
+S3_USE_PATH_STYLE: "true"
+S3_ENDPOINT: {{ .Values.externalS3.endpoint }}
+PLUGIN_STORAGE_OSS_BUCKET: {{ .Values.externalS3.bucketName.pluginDaemon | quote }}
+AWS_REGION: {{ .Values.externalS3.region }}
+{{- else }}
+PLUGIN_STORAGE_TYPE: local
+STORAGE_LOCAL_PATH: {{ .Values.pluginDaemon.persistence.mountPath | quote }}
 {{- end }}
 {{- end }}

--- a/charts/dify/templates/config.tpl
+++ b/charts/dify/templates/config.tpl
@@ -563,6 +563,11 @@ S3_USE_PATH_STYLE: "true"
 S3_ENDPOINT: {{ .Values.externalS3.endpoint }}
 PLUGIN_STORAGE_OSS_BUCKET: {{ .Values.externalS3.bucketName.pluginDaemon | quote }}
 AWS_REGION: {{ .Values.externalS3.region }}
+{{- else if and .Values.externalCOS.enabled .Values.externalCOS.bucketName.pluginDaemon }}
+PLUGIN_STORAGE_TYPE: "tencent_cos"
+TENCENT_COS_SECRET_ID: {{ .Values.externalCOS.secretId | quote }}
+TENCENT_COS_REGION: {{ .Values.externalCOS.region | quote }}
+PLUGIN_STORAGE_OSS_BUCKET: {{ .Values.externalCOS.bucketName.pluginDaemon | quote }}
 {{- else }}
 PLUGIN_STORAGE_TYPE: local
 STORAGE_LOCAL_PATH: {{ .Values.pluginDaemon.persistence.mountPath | quote }}

--- a/charts/dify/templates/credentials.tpl
+++ b/charts/dify/templates/credentials.tpl
@@ -150,6 +150,14 @@ API_KEY: {{ .Values.sandbox.auth.apiKey | b64enc | quote }}
 {{- define "dify.pluginDaemon.credentials" -}}
 {{ include "dify.db.credentials" . }}
 {{ include "dify.redis.credentials" . }}
+{{ include "dify.pluginDaemon.storage.credentials" . }}
 SERVER_KEY: {{ .Values.pluginDaemon.auth.serverKey | b64enc | quote }}
 DIFY_INNER_API_KEY: {{ .Values.pluginDaemon.auth.difyApiKey | b64enc | quote }}
+{{- end }}
+
+{{- define "dify.pluginDaemon.storage.credentials" -}}
+{{- if and .Values.externalS3.enabled .Values.externalS3.bucketName.pluginDaemon }}
+AWS_ACCESS_KEY: {{ .Values.externalS3.accessKey | b64enc | quote }}
+AWS_SECRET_KEY: {{ .Values.externalS3.secretKey | b64enc | quote }}
+{{- end }}
 {{- end }}

--- a/charts/dify/templates/credentials.tpl
+++ b/charts/dify/templates/credentials.tpl
@@ -159,5 +159,7 @@ DIFY_INNER_API_KEY: {{ .Values.pluginDaemon.auth.difyApiKey | b64enc | quote }}
 {{- if and .Values.externalS3.enabled .Values.externalS3.bucketName.pluginDaemon }}
 AWS_ACCESS_KEY: {{ .Values.externalS3.accessKey | b64enc | quote }}
 AWS_SECRET_KEY: {{ .Values.externalS3.secretKey | b64enc | quote }}
+{{- else if and .Values.externalCOS.enabled .Values.externalCOS.bucketName.pluginDaemon }}
+TENCENT_COS_SECRET_KEY: {{ .Values.externalCOS.secretKey | b64enc | quote }}
 {{- end }}
 {{- end }}

--- a/charts/dify/templates/plugin-daemon-deployment.yaml
+++ b/charts/dify/templates/plugin-daemon-deployment.yaml
@@ -1,5 +1,5 @@
-{{- $usePvc := not (or .Values.externalS3.enabled .Values.externalAzureBlobStorage.enabled .Values.externalOSS.enabled .Values.externalCOS.enabled) -}}
 {{- if and .Values.pluginDaemon.enabled}}
+{{- $usePvc := not (or (and .Values.externalS3.enabled .Values.externalS3.bucketName.pluginDaemon)) -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -86,9 +86,11 @@ spec:
         resources:
           {{- toYaml .Values.pluginDaemon.resources | nindent 12 }}
         volumeMounts:
+        {{- if $usePvc }}
         - name: app-data
           mountPath: {{ .Values.pluginDaemon.persistence.mountPath | quote }}
           subPath: {{ .Values.pluginDaemon.persistence.persistentVolumeClaim.subPath | default "" }}
+        {{- end }}
     {{- if and (.Values.nodeSelector) (not .Values.pluginDaemon.nodeSelector) }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
@@ -114,7 +116,9 @@ spec:
 {{ toYaml .Values.pluginDaemon.tolerations | indent 8 }}
     {{- end }}
       volumes:
+      {{- if $usePvc }}
       - name: app-data
         persistentVolumeClaim:
           claimName: {{ .Values.pluginDaemon.persistence.persistentVolumeClaim.existingClaim | default (printf "%s" (include "dify.pluginDaemon.fullname" . | trunc 58)) }}
+      {{- end }}
 {{- end }}

--- a/charts/dify/templates/plugin-daemon-deployment.yaml
+++ b/charts/dify/templates/plugin-daemon-deployment.yaml
@@ -1,3 +1,4 @@
+{{- $usePvc := not (or .Values.externalS3.enabled .Values.externalAzureBlobStorage.enabled .Values.externalOSS.enabled .Values.externalCOS.enabled) -}}
 {{- if and .Values.pluginDaemon.enabled}}
 apiVersion: apps/v1
 kind: Deployment

--- a/charts/dify/templates/pvc.yaml
+++ b/charts/dify/templates/pvc.yaml
@@ -92,7 +92,7 @@ spec:
 
 {{- $pvc := .Values.pluginDaemon.persistence.persistentVolumeClaim -}}
 {{- if and .Values.pluginDaemon.enabled (not $pvc.existingClaim) }}
-
+{{- if not (and .Values.externalS3.enabled .Values.externalS3.bucketName.pluginDaemon) }}
 ---
 
 apiVersion: v1
@@ -118,4 +118,5 @@ spec:
   resources:
     requests:
       storage: {{ $pvc.size }}
+{{- end }}
 {{- end }}

--- a/charts/dify/templates/pvc.yaml
+++ b/charts/dify/templates/pvc.yaml
@@ -92,7 +92,11 @@ spec:
 
 {{- $pvc := .Values.pluginDaemon.persistence.persistentVolumeClaim -}}
 {{- if and .Values.pluginDaemon.enabled (not $pvc.existingClaim) }}
-{{- if not (and .Values.externalS3.enabled .Values.externalS3.bucketName.pluginDaemon) }}
+{{- if not (or
+  (and .Values.externalS3.enabled .Values.externalS3.bucketName.pluginDaemon)
+  (and .Values.externalCOS.enabled .Values.externalCOS.bucketName.pluginDaemon)
+)
+}}
 ---
 
 apiVersion: v1

--- a/charts/dify/values.yaml
+++ b/charts/dify/values.yaml
@@ -5,7 +5,7 @@
 image:
   api:
     repository: langgenius/dify-api
-    tag: "1.0.0"
+    tag: "1.2.0"
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -16,7 +16,7 @@ image:
 
   web:
     repository: langgenius/dify-web
-    tag: "1.0.0"
+    tag: "1.2.0"
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -27,7 +27,7 @@ image:
 
   sandbox:
     repository: langgenius/dify-sandbox
-    tag: "0.2.10"
+    tag: "0.2.11"
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -60,7 +60,7 @@ image:
 
   pluginDaemon:
     repository: langgenius/dify-plugin-daemon
-    tag: 0.0.3-local
+    tag: 0.0.7-local
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -2995,10 +2995,12 @@ externalS3:
   accessKey: "ak-difyai"
   secretKey: "sk-difyai"
   useSSL: false
-  bucketName: "difyai"
-  rootPath: ""
+  bucketName:
+    # Shared storage for `api` and `worker`
+    api: "difyai"
+    # If specifed, `pluginDaemon` will use this bucket instead of binding `PersistentVolume` for data persistence
+    pluginDaemon:
   useIAM: false
-  iamEndpoint: ""
   region: "us-east-1"
 
 ###################################

--- a/charts/dify/values.yaml
+++ b/charts/dify/values.yaml
@@ -623,6 +623,9 @@ pluginDaemon:
     serverKey: "lYkiYYT6owG+71oLerGzA7GXCgOT++6ovaezWAjpCjf+Sjc3ZtU+qUEi"
     # A separate key for interactions between `api`(`worker`) and `pluginDaemon`
     difyApiKey: "QaHbTe77CtuXmsfyhR7+vRjI/+XbV1AaFy691iy+kGDv2Jvy0/eAh8Y1"
+  ## Storage for `pluginDaemon`
+  ## Ignored if external object storage were configured via `.Values.externalS3` sections.
+  ##
   persistence:
     mountPath: "/app/storage"
     annotations:
@@ -2998,7 +3001,7 @@ externalS3:
   bucketName:
     # Shared storage for `api` and `worker`
     api: "difyai"
-    # If specifed, `pluginDaemon` will use this bucket instead of binding `PersistentVolume` for data persistence
+    # If specifed, `pluginDaemon` will use this bucket instead of binding `PersistentVolume` for data persistence (only used when `externalS3.enabled` is set to `true`).
     pluginDaemon:
   useIAM: false
   region: "us-east-1"
@@ -3046,7 +3049,10 @@ externalCOS:
   secretKey: "your-secret-key"
   secretId: "your-secret-id"
   region: "your-region"
-  bucketName: "your-bucket-name"
+  bucketName:
+    api: "your-bucket-name"
+    # If specifed, `pluginDaemon` will use this bucket instead of binding `PersistentVolume` for data persistence (only used when `externalCOS.enabled` is set to `true`).
+    pluginDaemon:
   scheme: "your-scheme"
 
 ###################################


### PR DESCRIPTION
## Brief
Allow object storage instead of `PersistVolumeClaim` as data persistence for `pluginDaemon`
This feature comes in handy when deploying on clouds that doesn't come with `PVC` that suport `ReadRriteMany` access modes. 
## Tweaked
- `externalS3.bucketName`->`externalS3.bucketName.api` and `externalS3.bucketName.pluginDaemon`
- `externalCOS.bucketName`->`externalCOS.bucketName.api` and `externalCOS.bucketName.pluginDaemon`
- Bump `dify` version to `1.2.0` to support this feature
## Related issues
#160
## Supported Object Storages
- Amazon S3 compatible services
- Tencent COS