### PR TITLE
Fix CELERY_BROKER_URL when external redis has SSL=True

### DIFF
--- a/charts/dify/templates/config.tpl
+++ b/charts/dify/templates/config.tpl
@@ -246,7 +246,11 @@ REDIS_DB: "0"
 # Use redis as the broker, and redis db 1 for celery broker.
 {{- if .Values.externalRedis.enabled }}
   {{- with .Values.externalRedis }}
-# CELERY_BROKER_URL: {{ printf "redis://%s:%s@%s:%v/1" .username .password .host .port }}
+    {{- $scheme := "redis" }}
+    {{- if .useSSL }}
+      {{- $scheme = "rediss" }}
+    {{- end }}
+# CELERY_BROKER_URL: {{ printf "%s://%s:%s@%s:%v/1" $scheme .username .password .host .port }}
   {{- end }}
 {{- else if .Values.redis.enabled }}
 {{- $redisHost := printf "%s-redis-master" .Release.Name -}}

--- a/charts/dify/templates/credentials.tpl
+++ b/charts/dify/templates/credentials.tpl
@@ -95,7 +95,11 @@ REDIS_PASSWORD: {{ .auth.password | b64enc | quote }}
 # Use redis as the broker, and redis db 1 for celery broker.
 {{- if .Values.externalRedis.enabled }}
   {{- with .Values.externalRedis }}
-CELERY_BROKER_URL: {{ printf "redis://%s:%s@%s:%v/1" .username .password .host .port | b64enc | quote }}
+    {{- $scheme := "redis" }}
+    {{- if .useSSL }}
+      {{- $scheme = "rediss" }}
+    {{- end }}
+CELERY_BROKER_URL: {{ printf "%s://%s:%s@%s:%v/1" $scheme .username .password .host .port }}
   {{- end }}
 {{- else if .Values.redis.enabled }}
 {{- $redisHost := printf "%s-redis-master" .Release.Name -}}

--- a/charts/dify/templates/credentials.tpl
+++ b/charts/dify/templates/credentials.tpl
@@ -99,7 +99,7 @@ REDIS_PASSWORD: {{ .auth.password | b64enc | quote }}
     {{- if .useSSL }}
       {{- $scheme = "rediss" }}
     {{- end }}
-CELERY_BROKER_URL: {{ printf "%s://%s:%s@%s:%v/1" $scheme .username .password .host .port }}
+CELERY_BROKER_URL: {{ printf "%s://%s:%s@%s:%v/1" $scheme .username .password .host .port | b64enc | quote }}
   {{- end }}
 {{- else if .Values.redis.enabled }}
 {{- $redisHost := printf "%s-redis-master" .Release.Name -}}


### PR DESCRIPTION
Fixes Worker and API to ensure SSL when useSSL flag for external redis is true.