### PR TITLE
feature/s3-path-style-setting

### DIFF
--- a/charts/dify/templates/config.tpl
+++ b/charts/dify/templates/config.tpl
@@ -567,7 +567,7 @@ MARKETPLACE_ENABLED: "false"
 {{- define "dify.pluginDaemon.storage.config" -}}
 {{- if and .Values.externalS3.enabled .Values.externalS3.bucketName.pluginDaemon }}
 PLUGIN_STORAGE_TYPE: aws_s3
-S3_USE_PATH_STYLE: "true"
+S3_USE_PATH_STYLE: {{ .Values.externalS3.path_style | toString | quote }}
 S3_ENDPOINT: {{ .Values.externalS3.endpoint }}
 PLUGIN_STORAGE_OSS_BUCKET: {{ .Values.externalS3.bucketName.pluginDaemon | quote }}
 AWS_REGION: {{ .Values.externalS3.region }}

--- a/charts/dify/values.yaml
+++ b/charts/dify/values.yaml
@@ -2995,6 +2995,7 @@ externalPostgres:
 externalS3:
   enabled: false
   endpoint: "https://xxx.r2.cloudflarestorage.com"
+  path_style: "false"
   accessKey: "ak-difyai"
   secretKey: "sk-difyai"
   useSSL: false


### PR DESCRIPTION
S3 Path Style is deprecated on AWS.

Set Path Style as toggable (with default false) for other instance like Minio which supports both.