### PR TITLE
Fix: Remove duplicate securityContext 

### DIFF
--- a/charts/dify/templates/sandbox-deployment.yaml
+++ b/charts/dify/templates/sandbox-deployment.yaml
@@ -76,7 +76,7 @@ spec:
           tcpSocket:
             port: sandbox
         {{- end }}
-         {{- if .Values.sandbox.containerSecurityContext }}
+        {{- if .Values.sandbox.containerSecurityContext }}
         securityContext:
 {{ toYaml .Values.sandbox.containerSecurityContext | indent 10 }}
         {{- end }}

--- a/charts/dify/templates/sandbox-deployment.yaml
+++ b/charts/dify/templates/sandbox-deployment.yaml
@@ -76,6 +76,10 @@ spec:
           tcpSocket:
             port: sandbox
         {{- end }}
+         {{- if .Values.sandbox.containerSecurityContext }}
+        securityContext:
+{{ toYaml .Values.sandbox.containerSecurityContext | indent 10 }}
+        {{- end }}
         env:
         {{- if .Values.sandbox.extraEnv }}
           {{- toYaml .Values.sandbox.extraEnv | nindent 8 }}
@@ -91,11 +95,6 @@ spec:
             protocol: TCP
         resources:
           {{- toYaml .Values.sandbox.resources | nindent 12 }}
-        securityContext:
-          allowPrivilegeEscalation: {{ .Values.sandbox.privileged }}
-          {{- if .Values.sandbox.containerSecurityContext }}
-{{ toYaml .Values.sandbox.containerSecurityContext | indent 10 }}
-          {{- end }}
     {{- if and (.Values.nodeSelector) (not .Values.sandbox.nodeSelector) }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}

--- a/charts/dify/templates/sandbox-deployment.yaml
+++ b/charts/dify/templates/sandbox-deployment.yaml
@@ -76,10 +76,6 @@ spec:
           tcpSocket:
             port: sandbox
         {{- end }}
-        {{- if .Values.sandbox.containerSecurityContext }}
-        securityContext:
-{{ toYaml .Values.sandbox.containerSecurityContext | indent 10 }}
-        {{- end }}
         env:
         {{- if .Values.sandbox.extraEnv }}
           {{- toYaml .Values.sandbox.extraEnv | nindent 8 }}
@@ -97,6 +93,9 @@ spec:
           {{- toYaml .Values.sandbox.resources | nindent 12 }}
         securityContext:
           allowPrivilegeEscalation: {{ .Values.sandbox.privileged }}
+          {{- if .Values.sandbox.containerSecurityContext }}
+{{ toYaml .Values.sandbox.containerSecurityContext | indent 10 }}
+          {{- end }}
     {{- if and (.Values.nodeSelector) (not .Values.sandbox.nodeSelector) }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}

--- a/charts/dify/templates/ssrf-proxy-deployment.yaml
+++ b/charts/dify/templates/ssrf-proxy-deployment.yaml
@@ -61,6 +61,10 @@ spec:
         {{- if .Values.ssrfProxy.customStartupProbe }}
         startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.ssrfProxy.customStartupProbe "context" $) | nindent 10 }}
         {{- end }}
+        {{- if .Values.ssrfProxy.containerSecurityContext }}
+        securityContext:
+{{ toYaml .Values.ssrfProxy.containerSecurityContext | indent 10 }}
+        {{- end }}
         env:
         {{- if .Values.ssrfProxy.extraEnv }}
           {{- toYaml .Values.ssrfProxy.extraEnv | nindent 8 }}
@@ -81,11 +85,6 @@ spec:
         {{- end }}
         resources:
           {{- toYaml .Values.ssrfProxy.resources | nindent 12 }}
-        securityContext:
-          allowPrivilegeEscalation: {{ .Values.ssrfProxy.privileged }}
-          {{- if .Values.ssrfProxy.containerSecurityContext }}
-{{ toYaml .Values.ssrfProxy.containerSecurityContext | indent 10 }}
-          {{- end }}
     {{- if and (.Values.nodeSelector) (not .Values.ssrfProxy.nodeSelector) }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}

--- a/charts/dify/templates/ssrf-proxy-deployment.yaml
+++ b/charts/dify/templates/ssrf-proxy-deployment.yaml
@@ -61,10 +61,6 @@ spec:
         {{- if .Values.ssrfProxy.customStartupProbe }}
         startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.ssrfProxy.customStartupProbe "context" $) | nindent 10 }}
         {{- end }}
-        {{- if .Values.ssrfProxy.containerSecurityContext }}
-        securityContext:
-{{ toYaml .Values.ssrfProxy.containerSecurityContext | indent 10 }}
-        {{- end }}
         env:
         {{- if .Values.ssrfProxy.extraEnv }}
           {{- toYaml .Values.ssrfProxy.extraEnv | nindent 8 }}
@@ -87,6 +83,9 @@ spec:
           {{- toYaml .Values.ssrfProxy.resources | nindent 12 }}
         securityContext:
           allowPrivilegeEscalation: {{ .Values.ssrfProxy.privileged }}
+          {{- if .Values.ssrfProxy.containerSecurityContext }}
+{{ toYaml .Values.ssrfProxy.containerSecurityContext | indent 10 }}
+          {{- end }}
     {{- if and (.Values.nodeSelector) (not .Values.ssrfProxy.nodeSelector) }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}

--- a/charts/dify/values.yaml
+++ b/charts/dify/values.yaml
@@ -502,7 +502,6 @@ sandbox:
     clusterIP: ""
   auth:
     apiKey: "dify-sandbox"
-  privileged: false
   ## Sandbox ServiceAccount configuration
   ##
   serviceAccount:


### PR DESCRIPTION
Removes duplicate container securityContext in some deployments introduced in https://github.com/BorisPolonsky/dify-helm/commit/539467f5b92d7b3ff054cd2d0e3261e9bc5b2035