### PR TITLE
fix:When there are multiple pods, upgrading the plugin can cause a null pointer error in the plugin-daemon.

### DIFF
--- a/charts/dify/templates/config.tpl
+++ b/charts/dify/templates/config.tpl
@@ -554,7 +554,7 @@ PLUGIN_REMOTE_INSTALLING_HOST: "0.0.0.0"
 PLUGIN_REMOTE_INSTALLING_PORT: "5003"
 MAX_PLUGIN_PACKAGE_SIZE: "52428800"
 PLUGIN_STORAGE_LOCAL_ROOT: {{ .Values.pluginDaemon.persistence.mountPath | quote }}
-PLUGIN_WORKING_PATH: {{ printf "%s/cwd" .Values.pluginDaemon.persistence.mountPath | clean | quote }}
+PLUGIN_WORKING_PATH: /app/cwd
 DIFY_INNER_API_URL: "http://{{ template "dify.api.fullname" . }}:{{ .Values.api.service.port }}"
 {{- include "dify.marketplace.config" . }}
 {{- end }}


### PR DESCRIPTION
This is the final execution directory for the Python plugin. Each time a pod restarts, it reads the plugin from the PLUGIN_STORAGE_LOCAL_ROOT directory and installs it, so there’s no need to place it in a shared directory. However, when multiple pods perform upgrade or other write operations on the plugin simultaneously, it can cause issues with the plugin directory, making the plugin inaccessible.