### PR TITLE
fix worker, plugin-daemon and API services issue

### DIFF
--- a/charts/dify/templates/api-deployment.yaml
+++ b/charts/dify/templates/api-deployment.yaml
@@ -63,6 +63,39 @@ spec:
       securityContext:
 {{ toYaml .Values.api.podSecurityContext | indent 8 }}
       {{- end }}
+      initContainers:
+        - name: check-postgres
+          image: "{{ .Values.postgresql.image.registry }}/{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}"
+          command:
+            - sh
+            - -c
+            - |
+              until PGPASSWORD=$DB_PASSWORD pg_isready -h $DB_HOST -U $DB_USERNAME -d $DB_DATABASE ; do
+                echo "Waiting for PostgreSQL sequence to be available..."
+                sleep 1
+              done
+              echo "PostgreSQL is ready."
+          envFrom:
+          - configMapRef:
+              name: {{ template "dify.api.fullname" . }}
+          - secretRef:
+              name: {{ template "dify.api.fullname" . }}
+        - name: check-redis
+          image: "{{ .Values.redis.image.registry }}/{{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}"
+          command:
+            - sh
+            - -c
+            - |
+              until redis-cli -h $REDIS_HOST -p $REDIS_PORT -a $REDIS_PASSWORD ping | grep -q PONG; do
+                echo "Waiting for Redis service to be available..."
+                sleep 1
+              done
+              echo "Redis is ready."
+          envFrom:
+          - configMapRef:
+              name: {{ template "dify.api.fullname" . }}
+          - secretRef:
+              name: {{ template "dify.api.fullname" . }}
       containers:
       - image: "{{ .Values.image.api.repository }}:{{ default .Chart.AppVersion .Values.image.api.tag }}"
         imagePullPolicy: "{{ .Values.image.api.pullPolicy }}"

--- a/charts/dify/templates/plugin-daemon-deployment.yaml
+++ b/charts/dify/templates/plugin-daemon-deployment.yaml
@@ -64,6 +64,39 @@ spec:
       securityContext:
 {{ toYaml .Values.pluginDaemon.podSecurityContext | indent 8 }}
       {{- end }}
+      initContainers:
+        - name: check-postgres
+          image: "{{ .Values.postgresql.image.registry }}/{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}"
+          command:
+            - sh
+            - -c
+            - |
+              until PGPASSWORD=$DB_PASSWORD pg_isready -h $DB_HOST -U $DB_USERNAME -d $DB_DATABASE ; do
+                echo "Waiting for PostgreSQL sequence to be available..."
+                sleep 1
+              done
+              echo "PostgreSQL is ready."
+          envFrom:
+          - configMapRef:
+              name: {{ template "dify.pluginDaemon.fullname" . }}
+          - secretRef:
+              name: {{ template "dify.pluginDaemon.fullname" . }}
+        - name: check-redis
+          image: "{{ .Values.redis.image.registry }}/{{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}"
+          command:
+            - sh
+            - -c
+            - |
+              until redis-cli -h $REDIS_HOST -p $REDIS_PORT -a $REDIS_PASSWORD ping | grep -q PONG; do
+                echo "Waiting for Redis service to be available..."
+                sleep 1
+              done
+              echo "Redis is ready."
+          envFrom:
+          - configMapRef:
+              name: {{ template "dify.pluginDaemon.fullname" . }}
+          - secretRef:
+              name: {{ template "dify.pluginDaemon.fullname" . }}
       containers:
       - image: "{{ .Values.image.pluginDaemon.repository }}:{{ default .Chart.AppVersion .Values.image.pluginDaemon.tag }}"
         imagePullPolicy: "{{ .Values.image.pluginDaemon.pullPolicy }}"

--- a/charts/dify/templates/worker-deployment.yaml
+++ b/charts/dify/templates/worker-deployment.yaml
@@ -56,6 +56,26 @@ spec:
       securityContext:
 {{ toYaml .Values.worker.podSecurityContext | indent 8 }}
       {{- end }}
+      initContainers:
+        - name: check-api
+          image: "{{ .Values.postgresql.image.registry }}/{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}"
+          command:
+            - sh
+            - -c
+            - |
+              until curl http://{{ template "dify.api.fullname" . }}:{{ .Values.api.service.port }}/health; do
+                echo "Waiting for API service to be available..."
+                sleep 1
+              done
+              until PGPASSWORD=$DB_PASSWORD psql -h $DB_HOST -U $DB_USERNAME -d $DB_DATABASE -c "SELECT 1 FROM information_schema.sequences WHERE sequence_name='task_id_sequence';" | grep -q 1; do
+                echo "Waiting for PostgreSQL sequence to be available..."
+                sleep 1
+              done
+          envFrom:
+          - configMapRef:
+              name: {{ template "dify.worker.fullname" . }}
+          - secretRef:
+              name: {{ template "dify.worker.fullname" . }}
       containers:
       - image: "{{ .Values.image.api.repository }}:{{ default .Chart.AppVersion .Values.image.api.tag }}"
         imagePullPolicy: "{{ .Values.image.api.pullPolicy }}"

--- a/charts/dify/templates/worker-deployment.yaml
+++ b/charts/dify/templates/worker-deployment.yaml
@@ -58,7 +58,7 @@ spec:
       {{- end }}
       initContainers:
         - name: check-api
-          image: "{{ .Values.postgresql.image.registry }}/{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}"
+          image: "{{ .Values.image.proxy.repository }}:{{ .Values.image.proxy.tag }}"
           command:
             - sh
             - -c
@@ -67,6 +67,17 @@ spec:
                 echo "Waiting for API service to be available..."
                 sleep 1
               done
+          envFrom:
+          - configMapRef:
+              name: {{ template "dify.worker.fullname" . }}
+          - secretRef:
+              name: {{ template "dify.worker.fullname" . }}
+        - name: check-psql
+          image: "{{ .Values.postgresql.image.registry }}/{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}"
+          command:
+            - sh
+            - -c
+            - |
               until PGPASSWORD=$DB_PASSWORD psql -h $DB_HOST -U $DB_USERNAME -d $DB_DATABASE -c "SELECT 1 FROM information_schema.sequences WHERE sequence_name='task_id_sequence';" | grep -q 1; do
                 echo "Waiting for PostgreSQL sequence to be available..."
                 sleep 1
@@ -75,7 +86,7 @@ spec:
           - configMapRef:
               name: {{ template "dify.worker.fullname" . }}
           - secretRef:
-              name: {{ template "dify.worker.fullname" . }}
+              name: {{ template "dify.worker.fullname" . }}              
       containers:
       - image: "{{ .Values.image.api.repository }}:{{ default .Chart.AppVersion .Values.image.api.tag }}"
         imagePullPolicy: "{{ .Values.image.api.pullPolicy }}"


### PR DESCRIPTION
### **1.Fix errors such as "relation 'task_id_sequence' already exists" in the API service logs.**
**Cause**: Since the worker service and the API service use the same image, if the worker service starts faster than the API service, the worker service will create sequences like task_id_sequence, taskset_id_sequence and tables like celery_taskmeta, celery_tasksetmeta in the PostgreSQL database. When the API service starts afterward, it encounters errors like "relation 'task_id_sequence' already exists" during database migration.
**Fix**: Add initContainers in worker-deployment.yaml to check whether the API service has started normally. Only after confirming that the API service is up and verifying that fields like task_id_sequence have been created in the PostgreSQL database will the worker service start.

### **2.Fix the issue where the plugin-daemon and API services keep restarting.**
**Cause**: Since plugin-daemon and the API service need to connect to Redis and PostgreSQL, they require these databases to be up and running as a prerequisite.
**Fix**: Add initContainers to plugin-daemon and the API service to check whether Redis and PostgreSQL are running properly. Only after confirming their availability will the plugin-daemon and API services start.