### PR TITLE
fix: relation "task_id_sequence" already exists

### DIFF
--- a/charts/dify/templates/config.tpl
+++ b/charts/dify/templates/config.tpl
@@ -104,7 +104,8 @@ LOG_LEVEL: {{ .Values.worker.logLevel | quote }}
 {{ include "dify.redis.config" . }}
 # The configurations of celery broker.
 {{ include "dify.celery.config" . }}
-
+# The configurations of celery backend
+CELERY_BACKEND: redis
 {{ include "dify.storage.config" . }}
 # The Vector store configurations.
 {{ include "dify.vectordb.config" . }}


### PR DESCRIPTION
According this Dify issue: https://github.com/langgenius/dify/issues/19910#issuecomment-3083433596
fixes the relation "task_id_sequence" already exists
Fixes #224 
