### PR TITLE
Fix `PLUGIN_STORAGE_OSS_BUCKET` missing error when using OSS as data storage for `pluginDaemon`

### DIFF
--- a/charts/dify/templates/config.tpl
+++ b/charts/dify/templates/config.tpl
@@ -598,6 +598,7 @@ AWS_REGION: {{ .Values.externalS3.region | quote }}
 PLUGIN_STORAGE_TYPE: "aliyun_oss"
 ALIYUN_OSS_REGION: {{ .Values.externalOSS.region | quote }}
 ALIYUN_OSS_ENDPOINT: {{ .Values.externalOSS.endpoint | quote }}
+PLUGIN_STORAGE_OSS_BUCKET: {{ .Values.externalOSS.bucketName.pluginDaemon | quote }}
 ALIYUN_OSS_ACCESS_KEY_ID: {{ .Values.externalOSS.accessKey | quote }}
 # ALIYUN_OSS_ACCESS_KEY_SECRET: {{ .Values.externalOSS.secretKey | quote }}
 ALIYUN_OSS_AUTH_VERSION: {{ .Values.externalOSS.authVersion | quote }}


### PR DESCRIPTION
…storage for `pluginDaemon`