### PR TITLE
fix: including missing s3 iam config

### DIFF
--- a/charts/dify/templates/config.tpl
+++ b/charts/dify/templates/config.tpl
@@ -172,6 +172,7 @@ S3_BUCKET_NAME: {{ .Values.externalS3.bucketName.api | quote }}
 # S3_ACCESS_KEY: {{ .Values.externalS3.accessKey | quote }}
 # S3_SECRET_KEY: {{ .Values.externalS3.secretKey | quote }}
 S3_REGION: {{ .Values.externalS3.region | quote }}
+S3_USE_AWS_MANAGED_IAM: {{ .Values.externalS3.useIAM | toString | quote }}
 {{- else if .Values.externalAzureBlobStorage.enabled }}
 # The type of storage to use for storing user files. Supported values are `local`, `s3`, `azure-blob`, `aliyun-oss` and `google-storage`, Default: `local`
 STORAGE_TYPE: azure-blob


### PR DESCRIPTION
The externalS3.useIAM parameter was not being applied anywhere in the code, which caused errors when the API container attempted to access S3. After properly wiring it to configure S3_USE_AWS_MANAGED_IAM, the API was able to access S3 successfully.