### PR TITLE
Adding extra env. var to web container to address connection timeouts

### DIFF
--- a/charts/dify/values.yaml
+++ b/charts/dify/values.yaml
@@ -508,6 +508,8 @@ web:
   # Apply your own Environment Variables if necessary
   - name: EDITION
     value: "SELF_HOSTED"
+  - name: HOSTNAME
+    value: "0.0.0.0"
   service:
     port: 3000
     annotations: {}


### PR DESCRIPTION
The Next.js standalone build currently binds only to the pod’s primary IP and does not listen on 127.0.0.1 or 0.0.0.0.

As a result, when using kubectl port-forward, the tunnel tries to connect to 127.0.0.1:<port> inside the pod’s namespace, but the Next.js process is not listening there — it is only bound to the pod’s IP. This causes connection failures when forwarding ports.

This change updates the Helm chart to ensure the Next.js process binds in a way that is compatible with port-forwarding.

Extra information: https://github.com/langgenius/dify/issues/15022