### PR TITLE
chore: add VECTOR_INDEX_NAME_PREFIX for worker/api

### DIFF
--- a/charts/dify/templates/config.tpl
+++ b/charts/dify/templates/config.tpl
@@ -322,6 +322,9 @@ REDIS_DB: "0"
 {{- end }}
 
 {{- define "dify.vectordb.config" -}}
+{{- if .Values.vectorIndexNamePrefix }}
+VECTOR_INDEX_NAME_PREFIX: {{ .Values.vectorIndexNamePrefix | quote }}
+{{- end }}
 {{- if .Values.externalWeaviate.enabled }}
 # The type of vector store to use. Supported values are `weaviate`, `qdrant`, `milvus`, `pgvector`, `tencent`, `myscale`.
 VECTOR_STORE: weaviate

--- a/charts/dify/values.yaml
+++ b/charts/dify/values.yaml
@@ -3209,6 +3209,12 @@ externalRedis:
   useSSL: false
 
 ###################################
+# Vector Database Global Configuration
+###################################
+# Prefix used to create collection name in vector database
+vectorIndexNamePrefix: ""
+
+###################################
 # External Weaviate
 # - these configs take effect when `externalWeaviate.enabled` is true
 ###################################

--- a/ci/values/values-legacy.yaml
+++ b/ci/values/values-legacy.yaml
@@ -3204,6 +3204,12 @@ externalRedis:
   useSSL: false
 
 ###################################
+# Vector Database Global Configuration
+###################################
+# Prefix used to create collection name in vector database
+vectorIndexNamePrefix: "prefix-test.bbq"
+
+###################################
 # External Weaviate
 # - these configs take effect when `externalWeaviate.enabled` is true
 ###################################


### PR DESCRIPTION
#251 

@BorisPolonsky 

self-test log

```shell
~/w/dify-helm *regression/support-vec-idx-prefix> ./ci/scripts/test-helm-template.sh "values-legacy.yaml"
INFO: Testing Helm template rendering for: Helm Template Test
INFO: Using values file: values-legacy.yaml
INFO: Rendering Helm templates...
install.go:225: 2025-08-21 14:34:14.85091 +0800 CST m=+0.071547043 [debug] Original chart version: ""
install.go:242: 2025-08-21 14:34:14.85116 +0800 CST m=+0.071796834 [debug] CHART PATH: /Users/guohao/workspace/dify-helm/charts/dify

wrote /tmp/helm-output/dify/charts/redis/templates/serviceaccount.yaml
....
wrote /tmp/helm-output/dify/templates/tests/test-redis-connection.yaml

SUCCESS: Helm template rendering successful
INFO: Validating rendered YAML files...
SUCCESS: All rendered YAML files are valid
INFO: Checking rendered resources...
INFO: Total rendered resources:       40
INFO: ExternalSecret resources:        0
INFO: Secret resources:        6
INFO: PostgreSQL-related resources:        8
SUCCESS: No ExternalSecret resources found as expected in legacy mode
INFO: Template Rendering Summary for Helm Template Test:
----------------------------------------
Values file: values-legacy.yaml
Total resources:       40
ExternalSecrets:        0
Traditional Secrets:        6
PostgreSQL resources:        8
Status: PASSED
INFO: Rendered templates saved to: /tmp/test-outputs/values-legacy-output

~/w/dify-helm regression/support-vec-idx-prefix> grep -irn 'VECTOR_INDEX_NAME_PREFIX' /tmp/helm-output/dify
/tmp/helm-output/dify/templates/worker-config.yaml:56:  VECTOR_INDEX_NAME_PREFIX: "prefix-test.bbq"
/tmp/helm-output/dify/templates/api-config.yaml:83:  VECTOR_INDEX_NAME_PREFIX: "prefix-test.bbq"
```