### PR TITLE
feat (Database Configuration): Added external PostgreSQL connection p…

### DIFF
--- a/charts/dify/Chart.yaml
+++ b/charts/dify/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.28.1
+version: 0.28.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/dify/templates/config.tpl
+++ b/charts/dify/templates/config.tpl
@@ -188,6 +188,8 @@ MARKETPLACE_URL: {{ .Values.api.url.marketplace | quote }}
 DB_HOST: {{ .Values.externalPostgres.address }}
 DB_PORT: {{ .Values.externalPostgres.port | toString | quote }}
 DB_DATABASE: {{ .Values.externalPostgres.database.api | quote }}
+SQLALCHEMY_POOL_SIZE: {{ .Values.externalPostgres.maxOpenConns | default 30 | toString | quote }}
+SQLALCHEMY_POOL_RECYCLE: {{ .Values.externalPostgres.maxIdleConns | default 3600 | toString | quote }}
 {{- else if .Values.postgresql.enabled }}
   {{ with .Values.postgresql.global.postgresql.auth }}
   {{- if empty .username }}


### PR DESCRIPTION
…ool size and recycle configuration

Added SQLALCHEMY_POOL_SIZE and SQLALCHEMY_POOL_RECYCLE configuration options for external PostgreSQL connections, with default values ​​of 30 and 3600, respectively, to optimize database connection management.

fixed #261