### PR TITLE
Migrate default registry from `bitnami` to `bitnamilegacy`

### DIFF
--- a/charts/dify/values.yaml
+++ b/charts/dify/values.yaml
@@ -783,7 +783,7 @@ postgresql:
         database: "dify"
   image:
     registry: docker.io
-    repository: bitnami/postgresql
+    repository: bitnamilegacy/postgresql
     tag: 15.3.0-debian-11-r7
     pullPolicy: IfNotPresent
   ## @param architecture PostgreSQL architecture (`standalone` or `replication`)
@@ -1379,7 +1379,7 @@ redis:
   ##
   image:
     registry: docker.io
-    repository: bitnami/redis
+    repository: bitnamilegacy/redis
     tag: 7.0.11-debian-11-r12
     digest: ""
     ## Specify a imagePullPolicy
@@ -2292,7 +2292,7 @@ redis:
     ##
     image:
       registry: docker.io
-      repository: bitnami/redis-sentinel
+      repository: bitnamilegacy/redis-sentinel
       tag: 7.0.11-debian-11-r10
       digest: ""
       ## Specify a imagePullPolicy
@@ -2734,7 +2734,7 @@ redis:
     ##
     image:
       registry: docker.io
-      repository: bitnami/redis-exporter
+      repository: bitnamilegacy/redis-exporter
       tag: 1.50.0-debian-11-r13
       digest: ""
       pullPolicy: IfNotPresent
@@ -2988,7 +2988,7 @@ redis:
     ##
     image:
       registry: docker.io
-      repository: bitnami/bitnami-shell
+      repository: bitnamilegacy/bitnami-shell
       tag: 11-debian-11-r118
       digest: ""
       pullPolicy: IfNotPresent
@@ -3036,7 +3036,7 @@ redis:
     ##
     image:
       registry: docker.io
-      repository: bitnami/bitnami-shell
+      repository: bitnamilegacy/bitnami-shell
       tag: 11-debian-11-r118
       digest: ""
       pullPolicy: IfNotPresent


### PR DESCRIPTION
## Brief
Bitnami is deprecating their Debian-based images and moving them to a legacy repository starting August 28th, 2025. This change updates the default registry settings for `postgresql` and `redis` to use the Bitnami Legacy repository to ensure continued functionality.


## [Quote]⚠️ Important Notice: Upcoming changes to the Bitnami Catalog
Beginning August 28th, 2025, Bitnami will evolve its public catalog to offer a curated set of hardened, security-focused images under the new [Bitnami Secure Images initiative](https://news.broadcom.com/app-dev/broadcom-introduces-bitnami-secure-images-for-production-ready-containerized-applications). As part of this transition:

Granting community users access for the first time to security-optimized versions of popular container images.
Bitnami will begin deprecating support for non-hardened, Debian-based software images in its free tier and will gradually remove non-latest tags from the public catalog. As a result, community users will have access to a reduced number of hardened images. These images are published only under the “latest” tag and are intended for development purposes
Starting August 28th, over two weeks, all existing container images, including older or versioned tags (e.g., 2.50.0, 10.6), will be migrated from the public catalog (docker.io/bitnami) to the “Bitnami Legacy” repository (docker.io/bitnamilegacy), where they will no longer receive updates.
For production workloads and long-term support, users are encouraged to adopt Bitnami Secure Images, which include hardened containers, smaller attack surfaces, CVE transparency (via VEX/KEV), SBOMs, and enterprise support.
These changes aim to improve the security posture of all Bitnami users by promoting best practices for software supply chain integrity and up-to-date deployments. For more details, visit the https://github.com/bitnami/containers/issues/83267.
