### PR TITLE
Update CI Testing: Migrate default image registry from bitnami to bitnamilegacy

### DIFF
--- a/.github/workflows/ci-eso.yml
+++ b/.github/workflows/ci-eso.yml
@@ -366,7 +366,7 @@ jobs:
         run: |
           echo "Installing external PostgreSQL..."
           helm install external-postgres bitnami/postgresql \
-            --set image.repository="bitnamilegacy/postgresql"
+            --set image.repository="bitnamilegacy/postgresql" \
             --set auth.postgresPassword="difyai123456" \
             --set auth.database="dify" \
             --set primary.service.type="ClusterIP" \
@@ -412,7 +412,7 @@ jobs:
         run: |
           echo "Installing Elasticsearch for vector database testing..."
           helm install external-elasticsearch bitnami/elasticsearch \
-            --set image.repostory="bitnamilegacy/elasticsearch"
+            --set image.repostory="bitnamilegacy/elasticsearch" \
             --set auth.elasticPassword="elasticsearch123456" \
             --set master.replicaCount=1 \
             --set data.replicaCount=0 \

--- a/.github/workflows/ci-eso.yml
+++ b/.github/workflows/ci-eso.yml
@@ -84,7 +84,7 @@ jobs:
           EXTRACTED_IMAGES=$(ci/scripts/extract-images.sh values-eso.yaml github-actions 2>/dev/null)
 
           # Add additional images for ESO scenarios
-          ADDITIONAL_IMAGES="hashicorp/vault:latest bitnami/minio:2024-debian-12-r2 semitechnologies/weaviate:1.19.1 bitnami/elasticsearch:8.11.0 ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:latest"
+          ADDITIONAL_IMAGES="hashicorp/vault:latest bitnamilegacy/minio:2024-debian-12-r2 semitechnologies/weaviate:1.19.1 bitnamilegacy/elasticsearch:8.11.0 ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:latest"
 
           # Combine extracted and additional images
           ALL_IMAGES="$EXTRACTED_IMAGES $ADDITIONAL_IMAGES"
@@ -97,9 +97,9 @@ jobs:
           echo ""
           echo "Additional ESO-specific Images:"
           echo "hashicorp/vault:latest"
-          echo "bitnami/minio:2024-debian-12-r2"
+          echo "bitnamilegacy/minio:2024-debian-12-r2"
           echo "semitechnologies/weaviate:1.19.1"
-          echo "bitnami/elasticsearch:8.11.0"
+          echo "bitnamilegacy/elasticsearch:8.11.0"
           echo "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:latest"
 
           IMAGE_COUNT=$(echo "$ALL_IMAGES" | wc -w)
@@ -366,6 +366,7 @@ jobs:
         run: |
           echo "Installing external PostgreSQL..."
           helm install external-postgres bitnami/postgresql \
+            --set image.repository="bitnamilegacy/postgresql"
             --set auth.postgresPassword="difyai123456" \
             --set auth.database="dify" \
             --set primary.service.type="ClusterIP" \
@@ -384,6 +385,7 @@ jobs:
         run: |
           echo "Installing MinIO for S3 testing..."
           helm install minio bitnami/minio \
+            --set image.repository="bitnamilegacy/minio" \
             --set auth.rootUser="minio-root" \
             --set auth.rootPassword="minio123456" \
             --set defaultBuckets="difyai" \
@@ -397,6 +399,7 @@ jobs:
         run: |
           echo "Installing Redis instance"
           helm install test-redis bitnami/redis \
+            --set image.repository="bitnamilegacy/redis" \
             --set auth.password="difyai123456" \
             --set master.persistence.enabled=false \
             --set replica.replicaCount=0 \
@@ -409,6 +412,7 @@ jobs:
         run: |
           echo "Installing Elasticsearch for vector database testing..."
           helm install external-elasticsearch bitnami/elasticsearch \
+            --set image.repostory="bitnamilegacy/elasticsearch"
             --set auth.elasticPassword="elasticsearch123456" \
             --set master.replicaCount=1 \
             --set data.replicaCount=0 \

--- a/ci/scripts/extract-images.sh
+++ b/ci/scripts/extract-images.sh
@@ -47,11 +47,11 @@ DIFY_IMAGES=(
 
 # Common dependency images
 DEPENDENCY_IMAGES=(
-    "bitnami/postgresql:15.3.0-debian-11-r7"
-    "bitnami/redis:7.0.11-debian-11-r12"
-    "bitnami/redis-sentinel:7.0.11-debian-11-r10"
-    "bitnami/redis-exporter:1.50.0-debian-11-r13"
-    "bitnami/bitnami-shell:11-debian-11-r118"
+    "bitnamilegacy/postgresql:15.3.0-debian-11-r7"
+    "bitnamilegacy/redis:7.0.11-debian-11-r12"
+    "bitnamilegacy/redis-sentinel:7.0.11-debian-11-r10"
+    "bitnamilegacy/redis-exporter:1.50.0-debian-11-r13"
+    "bitnamilegacy/bitnami-shell:11-debian-11-r118"
 )
 
 # Common utility images

--- a/ci/values/values-eso-external-es.yaml
+++ b/ci/values/values-eso-external-es.yaml
@@ -666,7 +666,7 @@ postgresql:
         database: "dify"
   image:
     registry: docker.io
-    repository: bitnami/postgresql
+    repository: bitnamilegacy/postgresql
     tag: 15.3.0-debian-11-r7
     pullPolicy: IfNotPresent
   ## @param architecture PostgreSQL architecture (`standalone` or `replication`)
@@ -824,7 +824,7 @@ redis:
   ##
   image:
     registry: docker.io
-    repository: bitnami/redis
+    repository: bitnamilegacy/redis
     tag: 7.0.11-debian-11-r12
     digest: ""
     ## Specify a imagePullPolicy
@@ -1403,7 +1403,7 @@ redis:
     ##
     image:
       registry: docker.io
-      repository: bitnami/redis-exporter
+      repository: bitnamilegacy/redis-exporter
       tag: 1.50.0-debian-11-r13
       digest: ""
       pullPolicy: IfNotPresent
@@ -1657,7 +1657,7 @@ redis:
     ##
     image:
       registry: docker.io
-      repository: bitnami/bitnami-shell
+      repository: bitnamilegacy/bitnami-shell
       tag: 11-debian-11-r118
       digest: ""
       pullPolicy: IfNotPresent
@@ -1705,7 +1705,7 @@ redis:
     ##
     image:
       registry: docker.io
-      repository: bitnami/bitnami-shell
+      repository: bitnamilegacy/bitnami-shell
       tag: 11-debian-11-r118
       digest: ""
       pullPolicy: IfNotPresent

--- a/ci/values/values-eso-external-pg.yaml
+++ b/ci/values/values-eso-external-pg.yaml
@@ -1181,7 +1181,7 @@ redis:
   ##
   image:
     registry: docker.io
-    repository: bitnami/redis
+    repository: bitnamilegacy/redis
     tag: 7.0.11-debian-11-r12
     digest: ""
     ## Specify a imagePullPolicy
@@ -2094,7 +2094,7 @@ redis:
     ##
     image:
       registry: docker.io
-      repository: bitnami/redis-sentinel
+      repository: bitnamilegacy/redis-sentinel
       tag: 7.0.11-debian-11-r10
       digest: ""
       ## Specify a imagePullPolicy
@@ -2536,7 +2536,7 @@ redis:
     ##
     image:
       registry: docker.io
-      repository: bitnami/redis-exporter
+      repository: bitnamilegacy/redis-exporter
       tag: 1.50.0-debian-11-r13
       digest: ""
       pullPolicy: IfNotPresent
@@ -2790,7 +2790,7 @@ redis:
     ##
     image:
       registry: docker.io
-      repository: bitnami/bitnami-shell
+      repository: bitnamilegacy/bitnami-shell
       tag: 11-debian-11-r118
       digest: ""
       pullPolicy: IfNotPresent
@@ -2838,7 +2838,7 @@ redis:
     ##
     image:
       registry: docker.io
-      repository: bitnami/bitnami-shell
+      repository: bitnamilegacy/bitnami-shell
       tag: 11-debian-11-r118
       digest: ""
       pullPolicy: IfNotPresent

--- a/ci/values/values-eso-external-redis.yaml
+++ b/ci/values/values-eso-external-redis.yaml
@@ -663,7 +663,7 @@ postgresql:
         database: "dify"
   image:
     registry: docker.io
-    repository: bitnami/postgresql
+    repository: bitnamilegacy/postgresql
     tag: 15.3.0-debian-11-r7
     pullPolicy: IfNotPresent
   ## @param architecture PostgreSQL architecture (`standalone` or `replication`)

--- a/ci/values/values-eso-external-s3.yaml
+++ b/ci/values/values-eso-external-s3.yaml
@@ -663,7 +663,7 @@ postgresql:
         database: "dify"
   image:
     registry: docker.io
-    repository: bitnami/postgresql
+    repository: bitnamilegacy/postgresql
     tag: 15.3.0-debian-11-r7
     pullPolicy: IfNotPresent
   ## @param architecture PostgreSQL architecture (`standalone` or `replication`)
@@ -1260,7 +1260,7 @@ redis:
   ##
   image:
     registry: docker.io
-    repository: bitnami/redis
+    repository: bitnamilegacy/redis
     tag: 7.0.11-debian-11-r12
     digest: ""
     ## Specify a imagePullPolicy
@@ -2173,7 +2173,7 @@ redis:
     ##
     image:
       registry: docker.io
-      repository: bitnami/redis-sentinel
+      repository: bitnamilegacy/redis-sentinel
       tag: 7.0.11-debian-11-r10
       digest: ""
       ## Specify a imagePullPolicy
@@ -2615,7 +2615,7 @@ redis:
     ##
     image:
       registry: docker.io
-      repository: bitnami/redis-exporter
+      repository: bitnamilegacy/redis-exporter
       tag: 1.50.0-debian-11-r13
       digest: ""
       pullPolicy: IfNotPresent
@@ -2869,7 +2869,7 @@ redis:
     ##
     image:
       registry: docker.io
-      repository: bitnami/bitnami-shell
+      repository: bitnamilegacy/bitnami-shell
       tag: 11-debian-11-r118
       digest: ""
       pullPolicy: IfNotPresent
@@ -2917,7 +2917,7 @@ redis:
     ##
     image:
       registry: docker.io
-      repository: bitnami/bitnami-shell
+      repository: bitnamilegacy/bitnami-shell
       tag: 11-debian-11-r118
       digest: ""
       pullPolicy: IfNotPresent

--- a/ci/values/values-eso-otel.yaml
+++ b/ci/values/values-eso-otel.yaml
@@ -774,7 +774,7 @@ postgresql:
         database: "dify"
   image:
     registry: docker.io
-    repository: bitnami/postgresql
+    repository: bitnamilegacy/postgresql
     tag: 15.3.0-debian-11-r7
     pullPolicy: IfNotPresent
   ## @param architecture PostgreSQL architecture (`standalone` or `replication`)
@@ -1370,7 +1370,7 @@ redis:
   ##
   image:
     registry: docker.io
-    repository: bitnami/redis
+    repository: bitnamilegacy/redis
     tag: 7.0.11-debian-11-r12
     digest: ""
     ## Specify a imagePullPolicy
@@ -2283,7 +2283,7 @@ redis:
     ##
     image:
       registry: docker.io
-      repository: bitnami/redis-sentinel
+      repository: bitnamilegacy/redis-sentinel
       tag: 7.0.11-debian-11-r10
       digest: ""
       ## Specify a imagePullPolicy
@@ -2725,7 +2725,7 @@ redis:
     ##
     image:
       registry: docker.io
-      repository: bitnami/redis-exporter
+      repository: bitnamilegacy/redis-exporter
       tag: 1.50.0-debian-11-r13
       digest: ""
       pullPolicy: IfNotPresent
@@ -2979,7 +2979,7 @@ redis:
     ##
     image:
       registry: docker.io
-      repository: bitnami/bitnami-shell
+      repository: bitnamilegacy/bitnami-shell
       tag: 11-debian-11-r118
       digest: ""
       pullPolicy: IfNotPresent
@@ -3027,7 +3027,7 @@ redis:
     ##
     image:
       registry: docker.io
-      repository: bitnami/bitnami-shell
+      repository: bitnamilegacy/bitnami-shell
       tag: 11-debian-11-r118
       digest: ""
       pullPolicy: IfNotPresent

--- a/ci/values/values-eso.yaml
+++ b/ci/values/values-eso.yaml
@@ -774,7 +774,7 @@ postgresql:
         database: "dify"
   image:
     registry: docker.io
-    repository: bitnami/postgresql
+    repository: bitnamilegacy/postgresql
     tag: 15.3.0-debian-11-r7
     pullPolicy: IfNotPresent
   ## @param architecture PostgreSQL architecture (`standalone` or `replication`)
@@ -1370,7 +1370,7 @@ redis:
   ##
   image:
     registry: docker.io
-    repository: bitnami/redis
+    repository: bitnamilegacy/redis
     tag: 7.0.11-debian-11-r12
     digest: ""
     ## Specify a imagePullPolicy
@@ -2283,7 +2283,7 @@ redis:
     ##
     image:
       registry: docker.io
-      repository: bitnami/redis-sentinel
+      repository: bitnamilegacy/redis-sentinel
       tag: 7.0.11-debian-11-r10
       digest: ""
       ## Specify a imagePullPolicy
@@ -2725,7 +2725,7 @@ redis:
     ##
     image:
       registry: docker.io
-      repository: bitnami/redis-exporter
+      repository: bitnamilegacy/redis-exporter
       tag: 1.50.0-debian-11-r13
       digest: ""
       pullPolicy: IfNotPresent
@@ -2979,7 +2979,7 @@ redis:
     ##
     image:
       registry: docker.io
-      repository: bitnami/bitnami-shell
+      repository: bitnamilegacy/bitnami-shell
       tag: 11-debian-11-r118
       digest: ""
       pullPolicy: IfNotPresent
@@ -3027,7 +3027,7 @@ redis:
     ##
     image:
       registry: docker.io
-      repository: bitnami/bitnami-shell
+      repository: bitnamilegacy/bitnami-shell
       tag: 11-debian-11-r118
       digest: ""
       pullPolicy: IfNotPresent

--- a/ci/values/values-legacy-external-es.yaml
+++ b/ci/values/values-legacy-external-es.yaml
@@ -666,7 +666,7 @@ postgresql:
         database: "dify"
   image:
     registry: docker.io
-    repository: bitnami/postgresql
+    repository: bitnamilegacy/postgresql
     tag: 15.3.0-debian-11-r7
     pullPolicy: IfNotPresent
   ## @param architecture PostgreSQL architecture (`standalone` or `replication`)
@@ -1262,7 +1262,7 @@ redis:
   ##
   image:
     registry: docker.io
-    repository: bitnami/redis
+    repository: bitnamilegacy/redis
     tag: 7.0.11-debian-11-r12
     digest: ""
     ## Specify a imagePullPolicy
@@ -2175,7 +2175,7 @@ redis:
     ##
     image:
       registry: docker.io
-      repository: bitnami/redis-sentinel
+      repository: bitnamilegacy/redis-sentinel
       tag: 7.0.11-debian-11-r10
       digest: ""
       ## Specify a imagePullPolicy
@@ -2617,7 +2617,7 @@ redis:
     ##
     image:
       registry: docker.io
-      repository: bitnami/redis-exporter
+      repository: bitnamilegacy/redis-exporter
       tag: 1.50.0-debian-11-r13
       digest: ""
       pullPolicy: IfNotPresent
@@ -2871,7 +2871,7 @@ redis:
     ##
     image:
       registry: docker.io
-      repository: bitnami/bitnami-shell
+      repository: bitnamilegacy/bitnami-shell
       tag: 11-debian-11-r118
       digest: ""
       pullPolicy: IfNotPresent
@@ -2919,7 +2919,7 @@ redis:
     ##
     image:
       registry: docker.io
-      repository: bitnami/bitnami-shell
+      repository: bitnamilegacy/bitnami-shell
       tag: 11-debian-11-r118
       digest: ""
       pullPolicy: IfNotPresent

--- a/ci/values/values-legacy-external-pg.yaml
+++ b/ci/values/values-legacy-external-pg.yaml
@@ -666,7 +666,7 @@ postgresql:
         database: "dify"
   image:
     registry: docker.io
-    repository: bitnami/postgresql
+    repository: bitnamilegacy/postgresql
     tag: 15.3.0-debian-11-r7
     pullPolicy: IfNotPresent
   ## @param architecture PostgreSQL architecture (`standalone` or `replication`)
@@ -1262,7 +1262,7 @@ redis:
   ##
   image:
     registry: docker.io
-    repository: bitnami/redis
+    repository: bitnamilegacy/redis
     tag: 7.0.11-debian-11-r12
     digest: ""
     ## Specify a imagePullPolicy
@@ -2175,7 +2175,7 @@ redis:
     ##
     image:
       registry: docker.io
-      repository: bitnami/redis-sentinel
+      repository: bitnamilegacy/redis-sentinel
       tag: 7.0.11-debian-11-r10
       digest: ""
       ## Specify a imagePullPolicy
@@ -2617,7 +2617,7 @@ redis:
     ##
     image:
       registry: docker.io
-      repository: bitnami/redis-exporter
+      repository: bitnamilegacy/redis-exporter
       tag: 1.50.0-debian-11-r13
       digest: ""
       pullPolicy: IfNotPresent
@@ -2871,7 +2871,7 @@ redis:
     ##
     image:
       registry: docker.io
-      repository: bitnami/bitnami-shell
+      repository: bitnamilegacy/bitnami-shell
       tag: 11-debian-11-r118
       digest: ""
       pullPolicy: IfNotPresent
@@ -2919,7 +2919,7 @@ redis:
     ##
     image:
       registry: docker.io
-      repository: bitnami/bitnami-shell
+      repository: bitnamilegacy/bitnami-shell
       tag: 11-debian-11-r118
       digest: ""
       pullPolicy: IfNotPresent

--- a/ci/values/values-legacy-external-redis.yaml
+++ b/ci/values/values-legacy-external-redis.yaml
@@ -666,7 +666,7 @@ postgresql:
         database: "dify"
   image:
     registry: docker.io
-    repository: bitnami/postgresql
+    repository: bitnamilegacy/postgresql
     tag: 15.3.0-debian-11-r7
     pullPolicy: IfNotPresent
   ## @param architecture PostgreSQL architecture (`standalone` or `replication`)

--- a/ci/values/values-legacy-external-s3.yaml
+++ b/ci/values/values-legacy-external-s3.yaml
@@ -665,7 +665,7 @@ postgresql:
         database: "dify"
   image:
     registry: docker.io
-    repository: bitnami/postgresql
+    repository: bitnamilegacy/postgresql
     tag: 15.3.0-debian-11-r7
     pullPolicy: IfNotPresent
   ## @param architecture PostgreSQL architecture (`standalone` or `replication`)
@@ -1261,7 +1261,7 @@ redis:
   ##
   image:
     registry: docker.io
-    repository: bitnami/redis
+    repository: bitnamilegacy/redis
     tag: 7.0.11-debian-11-r12
     digest: ""
     ## Specify a imagePullPolicy
@@ -2174,7 +2174,7 @@ redis:
     ##
     image:
       registry: docker.io
-      repository: bitnami/redis-sentinel
+      repository: bitnamilegacy/redis-sentinel
       tag: 7.0.11-debian-11-r10
       digest: ""
       ## Specify a imagePullPolicy
@@ -2616,7 +2616,7 @@ redis:
     ##
     image:
       registry: docker.io
-      repository: bitnami/redis-exporter
+      repository: bitnamilegacy/redis-exporter
       tag: 1.50.0-debian-11-r13
       digest: ""
       pullPolicy: IfNotPresent
@@ -2870,7 +2870,7 @@ redis:
     ##
     image:
       registry: docker.io
-      repository: bitnami/bitnami-shell
+      repository: bitnamilegacy/bitnami-shell
       tag: 11-debian-11-r118
       digest: ""
       pullPolicy: IfNotPresent
@@ -2918,7 +2918,7 @@ redis:
     ##
     image:
       registry: docker.io
-      repository: bitnami/bitnami-shell
+      repository: bitnamilegacy/bitnami-shell
       tag: 11-debian-11-r118
       digest: ""
       pullPolicy: IfNotPresent

--- a/ci/values/values-legacy-otel.yaml
+++ b/ci/values/values-legacy-otel.yaml
@@ -774,7 +774,7 @@ postgresql:
         database: "dify"
   image:
     registry: docker.io
-    repository: bitnami/postgresql
+    repository: bitnamilegacy/postgresql
     tag: 15.3.0-debian-11-r7
     pullPolicy: IfNotPresent
   ## @param architecture PostgreSQL architecture (`standalone` or `replication`)
@@ -1370,7 +1370,7 @@ redis:
   ##
   image:
     registry: docker.io
-    repository: bitnami/redis
+    repository: bitnamilegacy/redis
     tag: 7.0.11-debian-11-r12
     digest: ""
     ## Specify a imagePullPolicy
@@ -2283,7 +2283,7 @@ redis:
     ##
     image:
       registry: docker.io
-      repository: bitnami/redis-sentinel
+      repository: bitnamilegacy/redis-sentinel
       tag: 7.0.11-debian-11-r10
       digest: ""
       ## Specify a imagePullPolicy
@@ -2725,7 +2725,7 @@ redis:
     ##
     image:
       registry: docker.io
-      repository: bitnami/redis-exporter
+      repository: bitnamilegacy/redis-exporter
       tag: 1.50.0-debian-11-r13
       digest: ""
       pullPolicy: IfNotPresent
@@ -2979,7 +2979,7 @@ redis:
     ##
     image:
       registry: docker.io
-      repository: bitnami/bitnami-shell
+      repository: bitnamilegacy/bitnami-shell
       tag: 11-debian-11-r118
       digest: ""
       pullPolicy: IfNotPresent
@@ -3027,7 +3027,7 @@ redis:
     ##
     image:
       registry: docker.io
-      repository: bitnami/bitnami-shell
+      repository: bitnamilegacy/bitnami-shell
       tag: 11-debian-11-r118
       digest: ""
       pullPolicy: IfNotPresent

--- a/ci/values/values-legacy.yaml
+++ b/ci/values/values-legacy.yaml
@@ -778,7 +778,7 @@ postgresql:
         database: "dify"
   image:
     registry: docker.io
-    repository: bitnami/postgresql
+    repository: bitnamilegacy/postgresql
     tag: 15.3.0-debian-11-r7
     pullPolicy: IfNotPresent
   ## @param architecture PostgreSQL architecture (`standalone` or `replication`)
@@ -1374,7 +1374,7 @@ redis:
   ##
   image:
     registry: docker.io
-    repository: bitnami/redis
+    repository: bitnamilegacy/redis
     tag: 7.0.11-debian-11-r12
     digest: ""
     ## Specify a imagePullPolicy
@@ -2287,7 +2287,7 @@ redis:
     ##
     image:
       registry: docker.io
-      repository: bitnami/redis-sentinel
+      repository: bitnamilegacy/redis-sentinel
       tag: 7.0.11-debian-11-r10
       digest: ""
       ## Specify a imagePullPolicy
@@ -2729,7 +2729,7 @@ redis:
     ##
     image:
       registry: docker.io
-      repository: bitnami/redis-exporter
+      repository: bitnamilegacy/redis-exporter
       tag: 1.50.0-debian-11-r13
       digest: ""
       pullPolicy: IfNotPresent
@@ -2983,7 +2983,7 @@ redis:
     ##
     image:
       registry: docker.io
-      repository: bitnami/bitnami-shell
+      repository: bitnamilegacy/bitnami-shell
       tag: 11-debian-11-r118
       digest: ""
       pullPolicy: IfNotPresent
@@ -3031,7 +3031,7 @@ redis:
     ##
     image:
       registry: docker.io
-      repository: bitnami/bitnami-shell
+      repository: bitnamilegacy/bitnami-shell
       tag: 11-debian-11-r118
       digest: ""
       pullPolicy: IfNotPresent


### PR DESCRIPTION
Bitnami is deprecating their Debian-based images and moving them to a legacy repository starting August 28th, 2025. This change updates the default registry settings in CI tests to use the Bitnami Legacy repository to ensure continued functionality.

This PR is in accord to #265 for continued functionality.