### PR TITLE
feat: Auto-detect HTTP/HTTPS protocol for Azure Blob Storage in PluginDaemon

### DIFF
--- a/charts/dify/templates/credentials.tpl
+++ b/charts/dify/templates/credentials.tpl
@@ -190,7 +190,15 @@ AWS_SECRET_KEY: {{ .Values.externalS3.secretKey | b64enc | quote }}
     {{- if hasSuffix ".r2.cloudflarestorage.com" .url }}
       {{- fail "Error: Cloudflare R2 is not supported with externalAzureBlobStorage configuration. Please use the externalS3 configuration for Cloudflare R2 storage." }}
     {{- end }}
-AZURE_BLOB_STORAGE_CONNECTION_STRING: {{ printf "DefaultEndpointsProtocol=https;AccountName=%s;AccountKey=%s;BlobEndpoint=%s;" .account .key .url | b64enc | quote }}
+    {{- $protocol := "" }}
+    {{- if hasPrefix "https://" .url }}
+      {{- $protocol = "https" }}
+    {{- else if hasPrefix "http://" .url }}
+      {{- $protocol = "http" }}
+    {{- else }}
+      {{- fail "Error: externalAzureBlobStorage.url must start with either 'http://' or 'https://'" }}
+    {{- end }}
+AZURE_BLOB_STORAGE_CONNECTION_STRING: {{ printf "DefaultEndpointsProtocol=%s;AccountName=%s;AccountKey=%s;BlobEndpoint=%s;" $protocol .account .key .url | b64enc | quote }}
   {{- end }}
 {{- else if and .Values.externalOSS.enabled .Values.externalOSS.bucketName.pluginDaemon }}
 ALIYUN_OSS_ACCESS_KEY_SECRET: {{ .Values.externalOSS.secretKey | b64enc | quote }}


### PR DESCRIPTION
- Automatically determine protocol from externalAzureBlobStorage.url
- Add validation to ensure URL starts with `http://` or `https://`

Tested with local [Azurite emulator instances](https://learn.microsoft.com/en-us/azure/storage/common/storage-install-azurite?tabs=visual-studio%2Cblob-storage):

```bash
docker run -p 20000:10000 --rm --name azure-storage -d mcr.microsoft.com/azure-storage/azurite azurite-blob --blobHost 0.0.0.0 --blobPort 10000
```

```yaml
###################################
# External Azure Blob Storage
# - these configs are only used when `externalS3.enabled` is false and `externalAzureBlobStorage.enabled` is true
###################################
externalAzureBlobStorage:
  enabled: true
  url: "http://<REMOTE_IP>:20000/devstoreaccount1"
  account: "devstoreaccount1"
  key: "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw=="
  container: "difyai-container"
```

```bash
kubectl logs -n test-azure test-azure-dify-plugin-daemon-755cb4b665-rx6m4
2025/09/23 03:22:42 pool.go:32: [INFO]init routine pool, size: 10000
2025/09/23 03:22:42 init.go:103: [INFO]dify plugin db initialized
2025/09/23 03:22:42 manager.go:114: [INFO]start plugin manager daemon...
2025/09/23 03:22:42 init.go:20: [INFO]Persistence initialized
2025/09/23 03:22:42 watcher.go:17: [INFO]start to handle new plugins in path: plugin
2025/09/23 03:22:42 watcher.go:18: [INFO]Launching plugins with max concurrency: 2
[gnet] 2025-09-23T03:22:42.7958119Z     INFO    logging/logger.go:256   Launching gnet with 8 event-loops, listening on: tcp://0.0.0.0:5003
[GIN] 2025/09/23 - 03:22:59 | 200 |      77.334µs |     10.42.0.194 | GET      "/health/check"
```