### PR TITLE
Fix chart lint error

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-python@v5.3.0
         with:
-          python-version: '3.x'
+          python-version: '3.12'
           check-latest: true
 
       - name: Set up chart-testing


### PR DESCRIPTION
Set python version as `3.12` instead of `3.x` to meet `yamale` requirements.