### PR TITLE
Fix nil pointer error in Redis connection test

### DIFF
--- a/charts/dify/templates/tests/test-redis-connection.yaml
+++ b/charts/dify/templates/tests/test-redis-connection.yaml
@@ -18,7 +18,7 @@ spec:
             - sh
             - -c
             - |
-{{- if .Values.redis.sentinel.enabled }}
+{{- if and .Values.redis.enabled .Values.redis.sentinel.enabled }}
               # Test connection to Redis with Sentinel enabled
               echo "Testing Redis Sentinel connection..."
               RELEASE_NAME="{{ .Release.Name }}"


### PR DESCRIPTION
Fixed nil pointer error when accessing `.Values.redis.sentinel.enabled`