### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -1,4 +1,6 @@
 name: Lint and Test Charts
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/BorisPolonsky/dify-helm/security/code-scanning/5](https://github.com/BorisPolonsky/dify-helm/security/code-scanning/5)

The best way to fix the problem is to add a `permissions:` block specifying the minimal required privilege for this workflow. Since the workflow only needs to read the contents of the repository to run linting and tests, `contents: read` is sufficient. This block should be added at the top level (root) of the workflow file, right after the `name:` and before the `on:` block to apply to all jobs. No changes to the functionality or steps are needed. No imports or method definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
