### PR TITLE
Clarify supported external databases in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,9 @@ The Nginx proxy handles traffic routing with the following rules:
 
 ### Supported External Components
 - [x] Redis (Standalone and Sentinel)
-- [x] PostgreSQL
+- External Database
+  - [x] PostgreSQL
+  - [x] MySQL
 - [x] Object Storage:
   - [x] Amazon S3
   - [x] Microsoft Azure Blob Storage


### PR DESCRIPTION
Updated the supported external components section to include MySQL and clarify PostgreSQL as an external database.