### PR TITLE
Add option to not override nginx user

### DIFF
--- a/charts/dify/templates/config.tpl
+++ b/charts/dify/templates/config.tpl
@@ -531,7 +531,9 @@ proxy_send_timeout 3600s;
 {{- end }}
 
 {{- define "dify.nginx.config.nginx" }}
+{{- if not .Values.proxy.useDefaultUser }}
 user  nginx;
+{{- end }}
 worker_processes  auto;
 {{- if .Values.proxy.log.persistence.enabled }}
 error_log  {{ .Values.proxy.log.persistence.mountPath }}/error.log notice;

--- a/charts/dify/values.yaml
+++ b/charts/dify/values.yaml
@@ -449,6 +449,9 @@ proxy:
   # Apply your own Environment Variables if necessary
   # - name: LANG
   #   value: "C.UTF-8"
+
+  ## @param proxy.useDefaultUser Use default user for nginx
+  useDefaultUser: false
   log:
     persistence:
       ## If true, create/use a Persistent Volume Claim for log


### PR DESCRIPTION
In nginx, the `user` directive can only be used when the process is started with the `root` user, which creates issues when trying to run the proxy in a non-root environment.  

The changes presented add the option to not set the directive, while preserving the default behavior of it being included.