### PR TITLE
refactor: migrate user defined persistence volumes to extraVolumes/extraVolumeMounts

### DIFF
--- a/charts/dify/templates/api-deployment.yaml
+++ b/charts/dify/templates/api-deployment.yaml
@@ -121,8 +121,8 @@ spec:
           mountPath: {{ .Values.api.persistence.mountPath | quote }}
           subPath: {{ .Values.api.persistence.persistentVolumeClaim.subPath | default "" }}
         {{- end }}
-        {{- if and .Values.api.persistence.enabled .Values.api.persistence.volumeMounts }}
-        {{- include "common.tplvalues.render" (dict "value" .Values.api.persistence.volumeMounts "context" $) | nindent 8 }}
+        {{- if .Values.api.extraVolumeMounts }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.api.extraVolumeMounts "context" $) | nindent 8 }}
         {{- end }}
     {{- if and (.Values.nodeSelector) (not .Values.api.nodeSelector) }}
       nodeSelector:
@@ -154,7 +154,7 @@ spec:
         persistentVolumeClaim:
           claimName: {{ .Values.api.persistence.persistentVolumeClaim.existingClaim | default (printf "%s" (include "dify.fullname" . | trunc 58)) }}
       {{- end }}
-      {{- if and .Values.api.persistence.enabled .Values.api.persistence.volumes }}
-      {{- include "common.tplvalues.render" (dict "value" .Values.api.persistence.volumes "context" $) | nindent 6 }}
+      {{- if .Values.api.extraVolumes }}
+      {{- include "common.tplvalues.render" (dict "value" .Values.api.extraVolumes "context" $) | nindent 6 }}
       {{- end }}
 {{- end }}

--- a/charts/dify/templates/beat-deployment.yaml
+++ b/charts/dify/templates/beat-deployment.yaml
@@ -85,9 +85,9 @@ spec:
             name: {{ template "dify.worker.fullname" . }}
         resources:
           {{- toYaml .Values.beat.resources | nindent 12 }}
-    {{- if and .Values.beat.persistence.enabled .Values.beat.persistence.volumeMounts }}
+    {{- if .Values.beat.extraVolumeMounts }}
     volumeMounts:
-    {{- include "common.tplvalues.render" (dict "value" .Values.beat.persistence.volumeMounts "context" $) | nindent 8 }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.beat.extraVolumeMounts "context" $) | nindent 8 }}
     {{- end }}
     {{- if and (.Values.nodeSelector) (not .Values.beat.nodeSelector) }}
       nodeSelector:
@@ -113,8 +113,8 @@ spec:
       tolerations:
 {{ toYaml .Values.beat.tolerations | indent 8 }}
     {{- end }}
-    {{- if and .Values.beat.persistence.enabled .Values.beat.persistence.volumes }}
+    {{- if .Values.beat.extraVolumes }}
       volumes:
-      {{- include "common.tplvalues.render" (dict "value" .Values.beat.persistence.volumes "context" $) | nindent 6 }}
+      {{- include "common.tplvalues.render" (dict "value" .Values.beat.extraVolumes "context" $) | nindent 6 }}
     {{- end }}
 {{- end }}

--- a/charts/dify/templates/plugin-daemon-deployment.yaml
+++ b/charts/dify/templates/plugin-daemon-deployment.yaml
@@ -109,8 +109,8 @@ spec:
           mountPath: {{ .Values.pluginDaemon.persistence.mountPath | quote }}
           subPath: {{ .Values.pluginDaemon.persistence.persistentVolumeClaim.subPath | default "" }}
         {{- end }}
-        {{- if and .Values.pluginDaemon.persistence.enabled .Values.pluginDaemon.persistence.volumeMounts }}
-        {{- include "common.tplvalues.render" (dict "value" .Values.pluginDaemon.persistence.volumeMounts "context" $) | nindent 8 }}
+        {{- if .Values.pluginDaemon.extraVolumeMounts }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.pluginDaemon.extraVolumeMounts "context" $) | nindent 8 }}
         {{- end }}
     {{- if and (.Values.nodeSelector) (not .Values.pluginDaemon.nodeSelector) }}
       nodeSelector:
@@ -142,7 +142,7 @@ spec:
         persistentVolumeClaim:
           claimName: {{ .Values.pluginDaemon.persistence.persistentVolumeClaim.existingClaim | default (printf "%s" (include "dify.pluginDaemon.fullname" . | trunc 58)) }}
       {{- end }}
-      {{- if and .Values.pluginDaemon.persistence.enabled .Values.pluginDaemon.persistence.volumes }}
-      {{- include "common.tplvalues.render" (dict "value" .Values.pluginDaemon.persistence.volumes "context" $) | nindent 6 }}
+      {{- if .Values.pluginDaemon.extraVolumes }}
+      {{- include "common.tplvalues.render" (dict "value" .Values.pluginDaemon.extraVolumes "context" $) | nindent 6 }}
       {{- end }}
 {{- end }}

--- a/charts/dify/templates/proxy-deployment.yaml
+++ b/charts/dify/templates/proxy-deployment.yaml
@@ -103,8 +103,8 @@ spec:
         - name: nginx-run
           mountPath: /var/run/nginx
         {{- end }}
-        {{- if and .Values.proxy.persistence.enabled .Values.proxy.persistence.volumeMounts }}
-        {{- include "common.tplvalues.render" (dict "value" .Values.proxy.persistence.volumeMounts "context" $) | nindent 8 }}
+        {{- if .Values.proxy.extraVolumeMounts }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.proxy.extraVolumeMounts "context" $) | nindent 8 }}
         {{- end }}
     {{- if and (.Values.nodeSelector) (not .Values.proxy.nodeSelector) }}
       nodeSelector:
@@ -146,7 +146,7 @@ spec:
       - name: nginx-run
         emptyDir: {}
       {{- end }}
-      {{- if and .Values.proxy.persistence.enabled .Values.proxy.persistence.volumes }}
-      {{- include "common.tplvalues.render" (dict "value" .Values.proxy.persistence.volumes "context" $) | nindent 6 }}
+      {{- if .Values.proxy.extraVolumes }}
+      {{- include "common.tplvalues.render" (dict "value" .Values.proxy.extraVolumes "context" $) | nindent 6 }}
       {{- end }}
 {{- end }}

--- a/charts/dify/templates/sandbox-deployment.yaml
+++ b/charts/dify/templates/sandbox-deployment.yaml
@@ -101,13 +101,13 @@ spec:
             protocol: TCP
         resources:
           {{- toYaml .Values.sandbox.resources | nindent 12 }}
-        {{- if and .Values.sandbox.persistence.enabled .Values.sandbox.persistence.volumeMounts }}
+        {{- if .Values.sandbox.extraVolumeMounts }}
         volumeMounts:
-        {{- include "common.tplvalues.render" (dict "value" .Values.sandbox.persistence.volumeMounts "context" $) | nindent 8 }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.sandbox.extraVolumeMounts "context" $) | nindent 8 }}
         {{- end }}
-      {{- if and .Values.sandbox.persistence.enabled .Values.sandbox.persistence.volumes }}
+      {{- if .Values.sandbox.extraVolumes }}
       volumes:
-      {{- include "common.tplvalues.render" (dict "value" .Values.sandbox.persistence.volumes "context" $) | nindent 6 }}
+      {{- include "common.tplvalues.render" (dict "value" .Values.sandbox.extraVolumes "context" $) | nindent 6 }}
       {{- end }}
     {{- if and (.Values.nodeSelector) (not .Values.sandbox.nodeSelector) }}
       nodeSelector:

--- a/charts/dify/templates/ssrf-proxy-deployment.yaml
+++ b/charts/dify/templates/ssrf-proxy-deployment.yaml
@@ -89,8 +89,8 @@ spec:
           mountPath: {{ .Values.ssrfProxy.log.persistence.mountPath | quote }}
           subPath: {{ .Values.ssrfProxy.log.persistence.persistentVolumeClaim.subPath | default "" }}
         {{- end }}
-        {{- if and .Values.ssrfProxy.persistence.enabled .Values.ssrfProxy.persistence.volumeMounts }}
-        {{- include "common.tplvalues.render" (dict "value" .Values.ssrfProxy.persistence.volumeMounts "context" $) | nindent 8 }}
+        {{- if .Values.ssrfProxy.extraVolumeMounts }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.ssrfProxy.extraVolumeMounts "context" $) | nindent 8 }}
         {{- end }}
         resources:
           {{- toYaml .Values.ssrfProxy.resources | nindent 12 }}
@@ -128,7 +128,7 @@ spec:
         persistentVolumeClaim:
           claimName: {{ .Values.ssrfProxy.log.persistence.persistentVolumeClaim.existingClaim | default (printf "%s-logs" (include "dify.ssrfProxy.fullname" . | trunc 58)) }}
       {{- end }}
-      {{- if and .Values.ssrfProxy.persistence.enabled .Values.ssrfProxy.persistence.volumes }}
-      {{- include "common.tplvalues.render" (dict "value" .Values.ssrfProxy.persistence.volumes "context" $) | nindent 6 }}
+      {{- if .Values.ssrfProxy.extraVolumes }}
+      {{- include "common.tplvalues.render" (dict "value" .Values.ssrfProxy.extraVolumes "context" $) | nindent 6 }}
       {{- end }}
 {{- end }}

--- a/charts/dify/templates/web-deployment.yaml
+++ b/charts/dify/templates/web-deployment.yaml
@@ -105,9 +105,9 @@ spec:
             protocol: TCP
         resources:
           {{- toYaml .Values.web.resources | nindent 12 }}
-        {{- if and .Values.web.persistence.enabled .Values.web.persistence.volumeMounts }}
+        {{- if .Values.web.extraVolumeMounts }}
         volumeMounts:
-        {{- include "common.tplvalues.render" (dict "value" .Values.web.persistence.volumeMounts "context" $) | nindent 8 }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.web.extraVolumeMounts "context" $) | nindent 8 }}
         {{- end }}
     {{- if and (.Values.nodeSelector) (not .Values.web.nodeSelector) }}
       nodeSelector:
@@ -133,8 +133,8 @@ spec:
       tolerations:
 {{ toYaml .Values.web.tolerations | indent 8 }}
     {{- end }}
-    {{- if and .Values.web.persistence.enabled .Values.web.persistence.volumes }}
+    {{- if .Values.web.extraVolumes }}
       volumes:
-      {{- include "common.tplvalues.render" (dict "value" .Values.web.persistence.volumes "context" $) | nindent 6 }}
+      {{- include "common.tplvalues.render" (dict "value" .Values.web.extraVolumes "context" $) | nindent 6 }}
     {{- end }}
 {{- end }}

--- a/charts/dify/templates/worker-deployment.yaml
+++ b/charts/dify/templates/worker-deployment.yaml
@@ -118,8 +118,8 @@ spec:
           mountPath: {{ .Values.api.persistence.mountPath | quote }}
           subPath: {{ .Values.api.persistence.persistentVolumeClaim.subPath | default "" }}
         {{- end }}
-        {{- if and .Values.worker.persistence.enabled .Values.worker.persistence.volumeMounts }}
-        {{- include "common.tplvalues.render" (dict "value" .Values.worker.persistence.volumeMounts "context" $) | nindent 8 }}
+        {{- if .Values.worker.extraVolumeMounts }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.worker.extraVolumeMounts "context" $) | nindent 8 }}
         {{- end }}
     {{- if and (.Values.nodeSelector) (not .Values.worker.nodeSelector) }}
       nodeSelector:
@@ -151,7 +151,7 @@ spec:
         persistentVolumeClaim:
           claimName: {{ .Values.api.persistence.persistentVolumeClaim.existingClaim | default (printf "%s" (include "dify.fullname" . | trunc 58)) }}
       {{- end }}
-      {{- if and .Values.worker.persistence.enabled .Values.worker.persistence.volumes }}
-      {{- include "common.tplvalues.render" (dict "value" .Values.worker.persistence.volumes "context" $) | nindent 6 }}
+      {{- if .Values.worker.extraVolumes }}
+      {{- include "common.tplvalues.render" (dict "value" .Values.worker.extraVolumes "context" $) | nindent 6 }}
       {{- end }}
 {{- end }}

--- a/charts/dify/values.schema.json
+++ b/charts/dify/values.schema.json
@@ -205,6 +205,8 @@
             }
           }
         },
+        "extraVolumes": { "type": "array" },
+        "extraVolumeMounts": { "type": "array" },
         "serviceAccount": {
           "type": "object",
           "properties": {
@@ -243,18 +245,8 @@
         "containerSecurityContext": { "type": "object" },
         "extraEnv": { "type": ["array", "null"] },
         "logLevel": { "type": "string" },
-        "persistence": {
-          "type": "object",
-          "properties": {
-            "enabled": { "type": "boolean" },
-            "volumes": { 
-              "type": "array"
-            },
-            "volumeMounts": { 
-              "type": "array"
-            }
-          }
-        },
+        "extraVolumes": { "type": "array" },
+        "extraVolumeMounts": { "type": "array" },
         "serviceAccount": {
           "type": "object",
           "properties": {
@@ -288,18 +280,8 @@
         "containerSecurityContext": { "type": "object" },
         "extraEnv": { "type": ["array", "null"] },
         "logLevel": { "type": "string" },
-        "persistence": {
-          "type": "object",
-          "properties": {
-            "enabled": { "type": "boolean" },
-            "volumes": { 
-              "type": "array"
-            },
-            "volumeMounts": { 
-              "type": "array"
-            }
-          }
-        },
+        "extraVolumes": { "type": "array" },
+        "extraVolumeMounts": { "type": "array" },
         "serviceAccount": {
           "type": "object",
           "properties": {
@@ -329,18 +311,8 @@
         "podSecurityContext": { "type": "object" },
         "containerSecurityContext": { "type": "object" },
         "extraEnv": { "type": ["array", "null"] },
-        "persistence": {
-          "type": "object",
-          "properties": {
-            "enabled": { "type": "boolean" },
-            "volumes": { 
-              "type": "array"
-            },
-            "volumeMounts": { 
-              "type": "array"
-            }
-          }
-        },
+        "extraVolumes": { "type": "array" },
+        "extraVolumeMounts": { "type": "array" },
         "log": {
           "type": "object",
           "properties": {
@@ -434,18 +406,8 @@
         "podSecurityContext": { "type": "object" },
         "containerSecurityContext": { "type": "object" },
         "extraEnv": { "type": "array" },
-        "persistence": {
-          "type": "object",
-          "properties": {
-            "enabled": { "type": "boolean" },
-            "volumes": { 
-              "type": "array"
-            },
-            "volumeMounts": { 
-              "type": "array"
-            }
-          }
-        },
+        "extraVolumes": { "type": "array" },
+        "extraVolumeMounts": { "type": "array" },
         "service": {
           "type": "object",
           "properties": {
@@ -526,6 +488,8 @@
         "podSecurityContext": { "type": "object" },
         "containerSecurityContext": { "type": "object" },
         "extraEnv": { "type": "array" },
+        "extraVolumes": { "type": "array" },
+        "extraVolumeMounts": { "type": "array" },
         "service": {
           "type": "object",
           "properties": {
@@ -539,18 +503,6 @@
           "type": "object",
           "properties": {
             "apiKey": { "type": "string" }
-          }
-        },
-        "persistence": {
-          "type": "object",
-          "properties": {
-            "enabled": { "type": "boolean" },
-            "volumes": { 
-              "type": "array"
-            },
-            "volumeMounts": { 
-              "type": "array"
-            }
           }
         },
         "serviceAccount": {
@@ -581,18 +533,8 @@
         "podSecurityContext": { "type": "object" },
         "containerSecurityContext": { "type": "object" },
         "extraEnv": { "type": ["array", "null"] },
-        "persistence": {
-          "type": "object",
-          "properties": {
-            "enabled": { "type": "boolean" },
-            "volumes": { 
-              "type": "array"
-            },
-            "volumeMounts": { 
-              "type": "array"
-            }
-          }
-        },
+        "extraVolumes": { "type": "array" },
+        "extraVolumeMounts": { "type": "array" },
         "log": {
           "type": "object",
           "properties": {
@@ -653,6 +595,8 @@
         "podSecurityContext": { "type": "object" },
         "containerSecurityContext": { "type": "object" },
         "extraEnv": { "type": ["array", "null"] },
+        "extraVolumes": { "type": "array" },
+        "extraVolumeMounts": { "type": "array" },
         "service": {
           "type": "object",
           "properties": {

--- a/charts/dify/values.yaml
+++ b/charts/dify/values.yaml
@@ -256,18 +256,9 @@ api:
   ## Ignored if `.Values.externalS3.enabled` is true
   ##
   persistence:
-    ## @param api.persistence.enabled Use volumes to persist data
-    ## (This controls the generic extra volumes/volumeMounts below; the default app-data PVC logic is controlled by external storage flags)
-    enabled: false
     mountPath: "/app/api/storage"
     annotations:
       helm.sh/resource-policy: keep
-    ## @param api.persistence.volumes Optionally specify extra list of additional volumes for the API pod(s)
-    ##
-    volumes: []
-    ## @param api.persistence.volumeMounts Optionally specify extra list of additional volumeMounts for the API container(s)
-    ##
-    volumeMounts: []
     persistentVolumeClaim:
       existingClaim: ""
       ## Dify App Data Persistent Volume Storage Class
@@ -281,6 +272,12 @@ api:
       accessModes: ReadWriteMany
       size: 5Gi
       subPath: ""
+  ## @param api.extraVolumes Optionally specify extra list of additional volumes for the API pod(s)
+  ##
+  extraVolumes: []
+  ## @param api.extraVolumeMounts Optionally specify extra list of additional volumeMounts for the API container(s)
+  ##
+  extraVolumeMounts: []
   ## Dify API ServiceAccount configuration
   ##
   serviceAccount:
@@ -354,16 +351,12 @@ worker:
   #        key: DB_PASSWORD
 
   logLevel: INFO
-  ## @param worker.persistence.enabled Use volumes to persist data
+  ## @param worker.extraVolumes Optionally specify extra list of additional volumes for the worker pod(s)
   ##
-  persistence:
-    enabled: false
-    ## @param worker.persistence.volumes Optionally specify extra list of additional volumes for the worker pod(s)
-    ##
-    volumes: []
-    ## @param worker.persistence.volumeMounts Optionally specify extra list of additional volumeMounts for the worker container(s)
-    ##
-    volumeMounts: []
+  extraVolumes: []
+  ## @param worker.extraVolumeMounts Optionally specify extra list of additional volumeMounts for the worker container(s)
+  ##
+  extraVolumeMounts: []
   ## Dify Worker ServiceAccount configuration
   ##
   serviceAccount:
@@ -422,16 +415,12 @@ beat:
   # - name: ENABLE_CLEAN_EMBEDDING_CACHE_TASK
   #   value: "false"
   logLevel: INFO
-  ## @param beat.persistence.enabled Use volumes to persist data
+  ## @param beat.extraVolumes Optionally specify extra list of additional volumes for the beat pod(s)
   ##
-  persistence:
-    enabled: false
-    ## @param beat.persistence.volumes Optionally specify extra list of additional volumes for the beat pod(s)
-    ##
-    volumes: []
-    ## @param beat.persistence.volumeMounts Optionally specify extra list of additional volumeMounts for the beat container(s)
-    ##
-    volumeMounts: []
+  extraVolumes: []
+  ## @param beat.extraVolumeMounts Optionally specify extra list of additional volumeMounts for the beat container(s)
+  ##
+  extraVolumeMounts: []
   ## celery beat ServiceAccount configuration
   ##
   serviceAccount:
@@ -513,16 +502,12 @@ proxy:
         accessModes: ReadWriteMany
         size: 1Gi
         subPath: ""
-  ## @param proxy.persistence.enabled Use volumes to persist data
+  ## @param proxy.extraVolumes Optionally specify extra list of additional volumes for the proxy pod(s)
   ##
-  persistence:
-    enabled: false
-    ## @param proxy.persistence.volumes Optionally specify extra list of additional volumes for the proxy pod(s)
-    ##
-    volumes: []
-    ## @param proxy.persistence.volumeMounts Optionally specify extra list of additional volumeMounts for the proxy container(s)
-    ##
-    volumeMounts: []
+  extraVolumes: []
+  ## @param proxy.extraVolumeMounts Optionally specify extra list of additional volumeMounts for the proxy container(s)
+  ##
+  extraVolumeMounts: []
   ## Proxy ServiceAccount configuration
   ##
   serviceAccount:
@@ -621,16 +606,12 @@ web:
   ## @param web.enableServiceLinks Disable this feature if additional environment variables would lead to `E2BIG` errors in case frontend were managed by `pm2`
   ##
   enableServiceLinks: false
-  ## @param web.persistence.enabled Use volumes to persist data
+  ## @param web.extraVolumes Optionally specify extra list of additional volumes for the web pod(s)
   ##
-  persistence:
-    enabled: false
-    ## @param web.persistence.volumes Optionally specify extra list of additional volumes for the web pod(s)
-    ##
-    volumes: []
-    ## @param web.persistence.volumeMounts Optionally specify extra list of additional volumeMounts for the web container(s)
-    ##
-    volumeMounts: []
+  extraVolumes: []
+  ## @param web.extraVolumeMounts Optionally specify extra list of additional volumeMounts for the web container(s)
+  ##
+  extraVolumeMounts: []
 
 sandbox:
   enabled: true
@@ -691,16 +672,12 @@ sandbox:
   #   value: "C.UTF-8"
   - name: WORKER_TIMEOUT
     value: "15"
-  ## @param sandbox.persistence.enabled Use volumes to persist data
+  ## @param sandbox.extraVolumes Optionally specify extra list of additional volumes for the Sandbox pod(s)
   ##
-  persistence:
-    enabled: false
-    ## @param sandbox.persistence.volumes Optionally specify extra list of additional volumes for the Sandbox pod(s)
-    ##
-    volumes: []
-    ## @param sandbox.persistence.volumeMounts Optionally specify extra list of additional volumeMounts for the Sandbox container(s)
-    ##
-    volumeMounts: []
+  extraVolumes: []
+  ## @param sandbox.extraVolumeMounts Optionally specify extra list of additional volumeMounts for the Sandbox container(s)
+  ##
+  extraVolumeMounts: []
   service:
     port: 8194
     annotations: {}
@@ -775,16 +752,12 @@ ssrfProxy:
         accessModes: ReadWriteMany
         size: 1Gi
         subPath: ""
-  ## @param ssrfProxy.persistence.enabled Use volumes to persist data
+  ## @param ssrfProxy.extraVolumes Optionally specify extra list of additional volumes for the ssrfProxy pod(s)
   ##
-  persistence:
-    enabled: false
-    ## @param ssrfProxy.persistence.volumes Optionally specify extra list of additional volumes for the ssrfProxy pod(s)
-    ##
-    volumes: []
-    ## @param ssrfProxy.persistence.volumeMounts Optionally specify extra list of additional volumeMounts for the ssrfProxy container(s)
-    ##
-    volumeMounts: []
+  extraVolumes: []
+  ## @param ssrfProxy.extraVolumeMounts Optionally specify extra list of additional volumeMounts for the ssrfProxy container(s)
+  ##
+  extraVolumeMounts: []
   service:
     port: 3128
     annotations: {}
@@ -851,18 +824,9 @@ pluginDaemon:
   ## Ignored if external object storage were configured via `.Values.externalS3` sections.
   ##
   persistence:
-    ## @param pluginDaemon.persistence.enabled Use volumes to persist data
-    ##
-    enabled: false
     mountPath: "/app/storage"
     annotations:
       helm.sh/resource-policy: keep
-    ## @param pluginDaemon.persistence.volumes Optionally specify extra list of additional volumes for the pluginDaemon pod(s)
-    ##
-    volumes: []
-    ## @param pluginDaemon.persistence.volumeMounts Optionally specify extra list of additional volumeMounts for the pluginDaemon container(s)
-    ##
-    volumeMounts: []
     persistentVolumeClaim:
       existingClaim: ""
       ## Dify Plugin Daemon Persistent Volume Storage Class
@@ -876,6 +840,12 @@ pluginDaemon:
       accessModes: ReadWriteMany
       size: 5Gi
       subPath: ""
+  ## @param pluginDaemon.extraVolumes Optionally specify extra list of additional volumes for the pluginDaemon pod(s)
+  ##
+  extraVolumes: []
+  ## @param pluginDaemon.extraVolumeMounts Optionally specify extra list of additional volumeMounts for the pluginDaemon container(s)
+  ##
+  extraVolumeMounts: []
   marketplace:
     enabled: true
     # Takes effect only if built-in `nginx` were enabled


### PR DESCRIPTION
- Replace `persistence.volumes`/`persistence.volumeMounts` with component-level `extraVolumes`/`extraVolumeMounts` across all components.
- Update `values.schema.json` and templates accordingly.