### PR TITLE
feat(proxy): Make nginx worker_processes configurable

### DIFF
--- a/charts/dify/templates/config.tpl
+++ b/charts/dify/templates/config.tpl
@@ -534,7 +534,7 @@ proxy_send_timeout 3600s;
 {{- if or (not .Values.proxy.containerSecurityContext.enabled) (and .Values.proxy.containerSecurityContext.enabled (eq (int (default 0 .Values.proxy.containerSecurityContext.runAsUser)) 0)) }}
 user  nginx;
 {{- end }}
-worker_processes  auto;
+worker_processes  {{ .Values.proxy.workerProcesses | default "auto" }};
 {{- if .Values.proxy.log.persistence.enabled }}
 error_log  {{ .Values.proxy.log.persistence.mountPath }}/error.log notice;
 {{- end }}

--- a/charts/dify/values.schema.json
+++ b/charts/dify/values.schema.json
@@ -307,6 +307,7 @@
         "customReadinessProbe": { "type": "object" },
         "customStartupProbe": { "type": "object" },
         "clientMaxBodySize": { "type": "string" },
+        "workerProcesses": { "type": ["string", "integer"] },
         "updateStrategy": { "type": "object" },
         "podSecurityContext": { "type": "object" },
         "containerSecurityContext": { "type": "object" },

--- a/charts/dify/values.yaml
+++ b/charts/dify/values.yaml
@@ -456,6 +456,8 @@ proxy:
   customStartupProbe: {}
   ## @param proxy.clientMaxBodySize Custom client_max_body_size param nginx default: 15m
   clientMaxBodySize: ""
+  ## @param proxy.workerProcesses Number of worker processes for nginx. Set to 'auto' (string) to automatically detect the number of available CPUs, or specify an integer (e.g., 4) for a fixed number of worker processes.
+  workerProcesses: "auto"
   ## @param proxy.updateStrategy Update strategy type and configuration parameters
   ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
   updateStrategy: {}


### PR DESCRIPTION
## Make nginx worker_processes configurable

### Problem

`worker_processes auto;` detects the host's total CPU count, not the container's CPU limit.

### Solution

Add `proxy.workerProcesses` parameter to configure nginx worker processes. Defaults to `auto` for backward compatibility.

### Usage
```yaml
proxy:
  resources:
    limits:
      cpu: '4'
  workerProcesses: 4  # Match CPU limit (Recommended)
```