### PR TITLE
Set Redis and Celery domain names regarding customized `fullname` in built-in Redis

### DIFF
--- a/charts/dify/templates/_helpers.tpl
+++ b/charts/dify/templates/_helpers.tpl
@@ -217,3 +217,23 @@ Create the name of the service account to use for the Dify Plugin Daemon
     {{ default "default" .Values.pluginDaemon.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Create the Redis fullname following the same logic as the Redis subchart's common.names.fullname.
+This matches the naming convention used by the Bitnami Redis chart.
+Note: This helper should only be called when redis.enabled is true.
+*/}}
+{{- define "dify.redis.fullname" -}}
+{{- if and .Values.redis .Values.redis.fullnameOverride -}}
+{{- .Values.redis.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else if .Values.redis -}}
+{{- $name := default "redis" .Values.redis.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- else -}}
+{{- printf "%s-redis" .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/dify/templates/config.tpl
+++ b/charts/dify/templates/config.tpl
@@ -308,15 +308,9 @@ REDIS_USE_SSL: {{ .useSSL | toString | quote }}
 REDIS_DB: {{ .db.app | default 0 | toString | quote }}
   {{- end }}
 {{- else if .Values.redis.enabled }}
-{{- $releaseName := printf "%s" .Release.Name -}}
 {{- $namespace := .Release.Namespace -}}
 {{- with .Values.redis }}
-  {{- $redisFullname := "" }}
-  {{- if .fullnameOverride }}
-  {{- $redisFullname = .fullnameOverride }}
-  {{- else }}
-  {{- $redisFullname = printf "%s-redis" $releaseName }}
-  {{- end }}
+  {{- $redisFullname := include "dify.redis.fullname" $ }}
   {{- if .sentinel.enabled }}
     {{- $sentinelPort := .sentinel.service.ports.sentinel | int -}}
     {{- $masterSet := .sentinel.masterSet -}}
@@ -372,15 +366,9 @@ CELERY_USE_SENTINEL: "true"
     {{- end }}
   {{- end }}
 {{- else if .Values.redis.enabled }}
-{{- $releaseName := printf "%s" .Release.Name -}}
 {{- $namespace := .Release.Namespace -}}
 {{- with .Values.redis }}
-  {{- $redisFullname := "" }}
-  {{- if .fullnameOverride }}
-  {{- $redisFullname = .fullnameOverride }}
-  {{- else }}
-  {{- $redisFullname = printf "%s-redis" $releaseName }}
-  {{- end }}
+  {{- $redisFullname := include "dify.redis.fullname" $ }}
   {{- if .sentinel.enabled }}
     {{- $sentinelPort := .sentinel.service.ports.sentinel | int -}}
     {{- $masterSet := .sentinel.masterSet -}}

--- a/charts/dify/templates/credentials.tpl
+++ b/charts/dify/templates/credentials.tpl
@@ -137,15 +137,9 @@ CELERY_BROKER_URL: {{ printf "%s://%s:%s@%s:%v/%v" $scheme .username .password .
     {{- end }}
   {{- end }}
 {{- else if .Values.redis.enabled }}
-{{- $releaseName := printf "%s" .Release.Name -}}
 {{- $namespace := .Release.Namespace -}}
 {{- with .Values.redis }}
-  {{- $redisFullname := "" }}
-  {{- if .fullnameOverride }}
-  {{- $redisFullname = .fullnameOverride }}
-  {{- else }}
-  {{- $redisFullname = printf "%s-redis" $releaseName }}
-  {{- end }}
+  {{- $redisFullname := include "dify.redis.fullname" $ }}
   {{- if .sentinel.enabled }}
     {{- $sentinelPort := .sentinel.service.ports.sentinel | int -}}
     {{- $masterSet := .sentinel.masterSet -}}


### PR DESCRIPTION
- Add `dify.redis.fullname` helper
- Set `REDIS_HOST`, `CELERY_BROKER_URL` and `REDIS_SENTINELS` regarding customized `fullname` of built-in Redis