### PR TITLE
Add CODE_EXECUTION_ENDPOINT for triggers

### DIFF
--- a/charts/dify/templates/config.tpl
+++ b/charts/dify/templates/config.tpl
@@ -157,6 +157,11 @@ OTEL_METRIC_EXPORT_INTERVAL: {{ .Values.api.otel.metricExportInterval | toString
 OTEL_BATCH_EXPORT_TIMEOUT: {{ .Values.api.otel.batchExportTimeout | toString | quote }}
 OTEL_METRIC_EXPORT_TIMEOUT: {{ .Values.api.otel.metricExportTimeout | toString | quote }}
 {{- end }}
+
+{{- if .Values.sandbox.enabled }}
+CODE_EXECUTION_ENDPOINT: http://{{ template "dify.sandbox.fullname" .}}:{{ .Values.sandbox.service.port }}
+{{- end }}
+
 {{- end }}
 
 {{- define "dify.web.config" -}}


### PR DESCRIPTION
CODE_EXECUTION_ENDPOINT needs to be set for the worker for code/tools to work when a workflow is run via a trigger such as schedule or webhook