### PR TITLE
feat(chart): optional shareProcessNamespace for all Dify workloads

### DIFF
--- a/charts/dify/templates/agentbox-deployment.yaml
+++ b/charts/dify/templates/agentbox-deployment.yaml
@@ -46,6 +46,9 @@ spec:
       {{- if .Values.agentbox.priorityClassName }}
       priorityClassName: {{ .Values.agentbox.priorityClassName | quote }}
       {{- end }}
+      {{- if .Values.agentbox.shareProcessNamespace }}
+      shareProcessNamespace: {{ .Values.agentbox.shareProcessNamespace }}
+      {{- end }}
       {{- if .Values.image.agentbox.pullSecrets }}
       imagePullSecrets:
         {{- range .Values.image.agentbox.pullSecrets }}

--- a/charts/dify/templates/api-deployment.yaml
+++ b/charts/dify/templates/api-deployment.yaml
@@ -46,6 +46,9 @@ spec:
       {{- if .Values.api.priorityClassName }}
       priorityClassName: {{ .Values.api.priorityClassName | quote }}
       {{- end }}
+      {{- if .Values.api.shareProcessNamespace }}
+      shareProcessNamespace: {{ .Values.api.shareProcessNamespace }}
+      {{- end }}
       {{- if eq .Release.Name "dify"}}
       {{/*
       Disable service environment variables,

--- a/charts/dify/templates/beat-deployment.yaml
+++ b/charts/dify/templates/beat-deployment.yaml
@@ -43,6 +43,9 @@ spec:
       {{- if .Values.beat.priorityClassName }}
       priorityClassName: {{ .Values.beat.priorityClassName | quote }}
       {{- end }}
+      {{- if .Values.beat.shareProcessNamespace }}
+      shareProcessNamespace: {{ .Values.beat.shareProcessNamespace }}
+      {{- end }}
       {{- if .Values.image.api.pullSecrets }}
       imagePullSecrets:
       {{- range .Values.image.api.pullSecrets }}

--- a/charts/dify/templates/plugin-daemon-deployment.yaml
+++ b/charts/dify/templates/plugin-daemon-deployment.yaml
@@ -69,7 +69,7 @@ spec:
         {{- toYaml .Values.pluginDaemon.hostAliases | nindent 8 }}
       {{- end }}
       {{- if .Values.pluginDaemon.shareProcessNamespace }}
-      shareProcessNamespace: true
+      shareProcessNamespace: {{ .Values.pluginDaemon.shareProcessNamespace }}
       {{- end }}
       {{- if .Values.pluginDaemon.podSecurityContext }}
       securityContext:

--- a/charts/dify/templates/proxy-deployment.yaml
+++ b/charts/dify/templates/proxy-deployment.yaml
@@ -44,6 +44,9 @@ spec:
       {{- if .Values.proxy.priorityClassName }}
       priorityClassName: {{ .Values.proxy.priorityClassName | quote }}
       {{- end }}
+      {{- if .Values.proxy.shareProcessNamespace }}
+      shareProcessNamespace: {{ .Values.proxy.shareProcessNamespace }}
+      {{- end }}
       {{- if .Values.image.proxy.pullSecrets }}
       imagePullSecrets:
         {{- range .Values.image.proxy.pullSecrets }}

--- a/charts/dify/templates/sandbox-deployment.yaml
+++ b/charts/dify/templates/sandbox-deployment.yaml
@@ -45,6 +45,9 @@ spec:
       {{- if .Values.sandbox.priorityClassName }}
       priorityClassName: {{ .Values.sandbox.priorityClassName | quote }}
       {{- end }}
+      {{- if .Values.sandbox.shareProcessNamespace }}
+      shareProcessNamespace: {{ .Values.sandbox.shareProcessNamespace }}
+      {{- end }}
       {{- if .Values.image.sandbox.pullSecrets }}
       imagePullSecrets:
         {{- range .Values.image.sandbox.pullSecrets }}

--- a/charts/dify/templates/ssrf-proxy-deployment.yaml
+++ b/charts/dify/templates/ssrf-proxy-deployment.yaml
@@ -44,6 +44,9 @@ spec:
       {{- if .Values.ssrfProxy.priorityClassName }}
       priorityClassName: {{ .Values.ssrfProxy.priorityClassName | quote }}
       {{- end }}
+      {{- if .Values.ssrfProxy.shareProcessNamespace }}
+      shareProcessNamespace: {{ .Values.ssrfProxy.shareProcessNamespace }}
+      {{- end }}
       {{- if .Values.image.ssrfProxy.pullSecrets }}
       imagePullSecrets:
         {{- range .Values.image.ssrfProxy.pullSecrets }}

--- a/charts/dify/templates/web-deployment.yaml
+++ b/charts/dify/templates/web-deployment.yaml
@@ -44,6 +44,9 @@ spec:
       {{- if .Values.web.priorityClassName }}
       priorityClassName: {{ .Values.web.priorityClassName | quote }}
       {{- end }}
+      {{- if .Values.web.shareProcessNamespace }}
+      shareProcessNamespace: {{ .Values.web.shareProcessNamespace }}
+      {{- end }}
       enableServiceLinks: {{ .Values.web.enableServiceLinks }}
       {{- if .Values.image.web.pullSecrets }}
       imagePullSecrets:

--- a/charts/dify/templates/worker-deployment.yaml
+++ b/charts/dify/templates/worker-deployment.yaml
@@ -46,6 +46,9 @@ spec:
       {{- if .Values.worker.priorityClassName }}
       priorityClassName: {{ .Values.worker.priorityClassName | quote }}
       {{- end }}
+      {{- if .Values.worker.shareProcessNamespace }}
+      shareProcessNamespace: {{ .Values.worker.shareProcessNamespace }}
+      {{- end }}
       {{- if .Values.image.api.pullSecrets }}
       imagePullSecrets:
       {{- range .Values.image.api.pullSecrets }}

--- a/charts/dify/values.schema.json
+++ b/charts/dify/values.schema.json
@@ -96,6 +96,11 @@
         "affinity": { "type": "object" },
         "tolerations": { "type": "array" },
         "priorityClassName": { "type": "string" },
+        "shareProcessNamespace": {
+          "type": "boolean",
+          "description": "Share a single process namespace between all of the containers in Dify API pods.",
+          "default": false
+        },
         "autoscaling": {
           "type": "object",
           "properties": {
@@ -259,6 +264,11 @@
         "affinity": { "type": "object" },
         "tolerations": { "type": "array" },
         "priorityClassName": { "type": "string" },
+        "shareProcessNamespace": {
+          "type": "boolean",
+          "description": "Share a single process namespace between all of the containers in Dify worker pods.",
+          "default": false
+        },
         "autoscaling": {
           "type": "object",
           "properties": {
@@ -312,6 +322,11 @@
         "affinity": { "type": "object" },
         "tolerations": { "type": "array" },
         "priorityClassName": { "type": "string" },
+        "shareProcessNamespace": {
+          "type": "boolean",
+          "description": "Share a single process namespace between all of the containers in Dify Celery Beat pods.",
+          "default": false
+        },
         "customLivenessProbe": { "type": "object" },
         "customReadinessProbe": { "type": "object" },
         "customStartupProbe": { "type": "object" },
@@ -362,6 +377,11 @@
         "affinity": { "type": "object" },
         "tolerations": { "type": "array" },
         "priorityClassName": { "type": "string" },
+        "shareProcessNamespace": {
+          "type": "boolean",
+          "description": "Share a single process namespace between all of the containers in Dify nginx proxy pods.",
+          "default": false
+        },
         "customLivenessProbe": { "type": "object" },
         "customReadinessProbe": { "type": "object" },
         "customStartupProbe": { "type": "object" },
@@ -431,6 +451,11 @@
         "affinity": { "type": "object" },
         "tolerations": { "type": "array" },
         "priorityClassName": { "type": "string" },
+        "shareProcessNamespace": {
+          "type": "boolean",
+          "description": "Share a single process namespace between all of the containers in Dify web pods.",
+          "default": false
+        },
         "autoscaling": {
           "type": "object",
           "properties": {
@@ -527,6 +552,11 @@
         "affinity": { "type": "object" },
         "tolerations": { "type": "array" },
         "priorityClassName": { "type": "string" },
+        "shareProcessNamespace": {
+          "type": "boolean",
+          "description": "Share a single process namespace between all of the containers in Dify sandbox pods.",
+          "default": false
+        },
         "autoscaling": {
           "type": "object",
           "properties": {
@@ -627,6 +657,11 @@
         "affinity": { "type": "object" },
         "tolerations": { "type": "array" },
         "priorityClassName": { "type": "string" },
+        "shareProcessNamespace": {
+          "type": "boolean",
+          "description": "Share a single process namespace between all of the containers in Dify agentbox pods.",
+          "default": false
+        },
         "podSecurityContext": { "type": "object" },
         "containerSecurityContext": { "type": "object" },
         "extraEnv": { "type": "array" },
@@ -684,6 +719,11 @@
         "affinity": { "type": "object" },
         "tolerations": { "type": "array" },
         "priorityClassName": { "type": "string" },
+        "shareProcessNamespace": {
+          "type": "boolean",
+          "description": "Share a single process namespace between all of the containers in Dify SSRF proxy pods.",
+          "default": false
+        },
         "customLivenessProbe": { "type": "object" },
         "customReadinessProbe": { "type": "object" },
         "customStartupProbe": { "type": "object" },
@@ -762,7 +802,8 @@
         "priorityClassName": { "type": "string" },
         "shareProcessNamespace": {
           "type": "boolean",
-          "description": "Share a single process namespace between all containers in Dify plugin daemon pods."
+          "description": "Share a single process namespace between all of the containers in Dify plugin daemon pods.",
+          "default": false
         },
         "customLivenessProbe": { "type": "object" },
         "customReadinessProbe": { "type": "object" },

--- a/charts/dify/values.schema.json
+++ b/charts/dify/values.schema.json
@@ -760,6 +760,10 @@
         "affinity": { "type": "object" },
         "tolerations": { "type": "array" },
         "priorityClassName": { "type": "string" },
+        "shareProcessNamespace": {
+          "type": "boolean",
+          "description": "Share a single process namespace between all containers in Dify plugin daemon pods."
+        },
         "customLivenessProbe": { "type": "object" },
         "customReadinessProbe": { "type": "object" },
         "customStartupProbe": { "type": "object" },

--- a/charts/dify/values.yaml
+++ b/charts/dify/values.yaml
@@ -132,6 +132,10 @@ api:
   affinity: {}
   tolerations: []
   priorityClassName: ""
+  ## @param api.shareProcessNamespace Share a single process namespace between all of the containers in Dify API pods
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/share-process-namespace/
+  ##
+  shareProcessNamespace: false
   autoscaling:
     enabled: false
     minReplicas: 1
@@ -333,6 +337,10 @@ worker:
   affinity: {}
   tolerations: []
   priorityClassName: ""
+  ## @param worker.shareProcessNamespace Share a single process namespace between all of the containers in Dify worker pods
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/share-process-namespace/
+  ##
+  shareProcessNamespace: false
   autoscaling:
     enabled: false
     minReplicas: 1
@@ -415,6 +423,10 @@ beat:
   affinity: {}
   tolerations: []
   priorityClassName: ""
+  ## @param beat.shareProcessNamespace Share a single process namespace between all of the containers in Dify Celery Beat pods
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/share-process-namespace/
+  ##
+  shareProcessNamespace: false
   ## Configure extra options for celery beat containers' liveness, readiness, and startup probes
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
   ## @param beat.customLivenessProbe Custom livenessProbe that overrides the default one (None)
@@ -484,6 +496,10 @@ proxy:
   affinity: {}
   tolerations: []
   priorityClassName: ""
+  ## @param proxy.shareProcessNamespace Share a single process namespace between all of the containers in Dify nginx proxy pods
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/share-process-namespace/
+  ##
+  shareProcessNamespace: false
   ## Configure extra options for proxy containers' liveness, readiness, and startup probes
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
   ## @param proxy.customLivenessProbe Custom livenessProbe that overrides the default one
@@ -577,6 +593,10 @@ web:
   affinity: {}
   tolerations: []
   priorityClassName: ""
+  ## @param web.shareProcessNamespace Share a single process namespace between all of the containers in Dify web pods
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/share-process-namespace/
+  ##
+  shareProcessNamespace: false
   autoscaling:
     enabled: false
     minReplicas: 1
@@ -667,6 +687,10 @@ sandbox:
   affinity: {}
   tolerations: []
   priorityClassName: ""
+  ## @param sandbox.shareProcessNamespace Share a single process namespace between all of the containers in Dify sandbox pods
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/share-process-namespace/
+  ##
+  shareProcessNamespace: false
   autoscaling:
     enabled: false
     minReplicas: 1
@@ -763,6 +787,10 @@ agentbox:
   affinity: {}
   tolerations: []
   priorityClassName: ""
+  ## @param agentbox.shareProcessNamespace Share a single process namespace between all of the containers in Dify agentbox pods
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/share-process-namespace/
+  ##
+  shareProcessNamespace: false
   podSecurityContext: {}
   # agentbox entrypoint needs root (mkdir /run/sshd, ssh-keygen, chpasswd, sshd). Override if your cluster restricts root.
   containerSecurityContext:
@@ -796,6 +824,10 @@ ssrfProxy:
   affinity: {}
   tolerations: []
   priorityClassName: ""
+  ## @param ssrfProxy.shareProcessNamespace Share a single process namespace between all of the containers in Dify SSRF proxy pods
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/share-process-namespace/
+  ##
+  shareProcessNamespace: false
   ## Configure extra options for ssrf proxy containers' liveness, readiness, and startup probes
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
   ## @param ssrfProxy.customLivenessProbe Custom livenessProbe that overrides the default one
@@ -877,13 +909,8 @@ pluginDaemon:
   affinity: {}
   tolerations: []
   priorityClassName: ""
-  ## @param pluginDaemon.shareProcessNamespace Enable process namespace sharing on the pod.
-  ## When true, the K8s pause container occupies PID 1 and the daemon runs as PID >1.
-  ## Required on Kubernetes because the embedded `dify_plugin` Python SDK (in every
-  ## plugin's .venv) self-terminates via `os._exit(-1)` when `os.getppid() == 1` — a
-  ## naive orphan check that assumes Docker `--init`/tini is injecting PID 1. Without
-  ## this flag, every plugin subprocess exits ~500ms after launch on Kubernetes and
-  ## dispatch requests fail with `no proper instance`.
+  ## @param pluginDaemon.shareProcessNamespace Share a single process namespace between all of the containers in Dify plugin daemon pods
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/share-process-namespace/
   ##
   shareProcessNamespace: false
   ## Configure extra options for plugin daemon containers' liveness, readiness, and startup probes

--- a/charts/dify/values.yaml
+++ b/charts/dify/values.yaml
@@ -911,6 +911,7 @@ pluginDaemon:
   priorityClassName: ""
   ## @param pluginDaemon.shareProcessNamespace Share a single process namespace between all of the containers in Dify plugin daemon pods
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/share-process-namespace/
+  ## Set to true to work around the issue described in https://github.com/BorisPolonsky/dify-helm/pull/402
   ##
   shareProcessNamespace: false
   ## Configure extra options for plugin daemon containers' liveness, readiness, and startup probes


### PR DESCRIPTION
## feat(chart): optional shareProcessNamespace for all Dify workloads

Follow-up to [#402](https://github.com/BorisPolonsky/dify-helm/pull/402).

### Summary

- Add optional `shareProcessNamespace` for **api**, **worker**, **beat**, **proxy**, **web**, **sandbox**, **agentbox**, and **ssrf-proxy** (in addition to **plugin daemon**), defaulting to `false` with aligned `values.yaml` and `values.schema.json` entries.
- **Plugin daemon:** render `shareProcessNamespace` from values instead of always emitting `true` when the flag is enabled.
- **Docs:** shorten plugin-daemon commentary to match other components; link #402 for the workaround context.

### Notes

- Templates gate on a truthy value so the field is omitted when `false` (minimal manifests).