### PR TITLE
feat: remove `CODE_MAX_*` overrides for code execution limits in the default setup

### DIFF
--- a/charts/dify/values.yaml
+++ b/charts/dify/values.yaml
@@ -203,20 +203,6 @@ api:
     # Won't check for updates if left empty
     #   value: https://updates.dify.ai
     value: ""
-  - name: CODE_MAX_NUMBER
-    value: "9223372036854775807"
-  - name: CODE_MIN_NUMBER
-    value: "-9223372036854775808"
-  - name: CODE_MAX_STRING_LENGTH
-    value: "80000"
-  - name: TEMPLATE_TRANSFORM_MAX_LENGTH
-    value: "80000"
-  - name: CODE_MAX_STRING_ARRAY_LENGTH
-    value: "30"
-  - name: CODE_MAX_OBJECT_ARRAY_LENGTH
-    value: "30"
-  - name: CODE_MAX_NUMBER_ARRAY_LENGTH
-    value: "1000"
   ## OpenTelemetry (OTEL) configuration
   otel:
     enabled: false

--- a/ci/values/values-eso-external-s3-pg-es-redis.yaml
+++ b/ci/values/values-eso-external-s3-pg-es-redis.yaml
@@ -58,20 +58,6 @@ api:
       # Won't check for updates if left empty
       #   value: https://updates.dify.ai
       value: ""
-    - name: CODE_MAX_NUMBER
-      value: "9223372036854775807"
-    - name: CODE_MIN_NUMBER
-      value: "-9223372036854775808"
-    - name: CODE_MAX_STRING_LENGTH
-      value: "80000"
-    - name: TEMPLATE_TRANSFORM_MAX_LENGTH
-      value: "80000"
-    - name: CODE_MAX_STRING_ARRAY_LENGTH
-      value: "30"
-    - name: CODE_MAX_OBJECT_ARRAY_LENGTH
-      value: "30"
-    - name: CODE_MAX_NUMBER_ARRAY_LENGTH
-      value: "1000"
   service:
     port: 5001
     annotations: {}

--- a/ci/values/values-eso-otel.yaml
+++ b/ci/values/values-eso-otel.yaml
@@ -111,20 +111,6 @@ api:
       # Won't check for updates if left empty
       #   value: https://updates.dify.ai
       value: ""
-    - name: CODE_MAX_NUMBER
-      value: "9223372036854775807"
-    - name: CODE_MIN_NUMBER
-      value: "-9223372036854775808"
-    - name: CODE_MAX_STRING_LENGTH
-      value: "80000"
-    - name: TEMPLATE_TRANSFORM_MAX_LENGTH
-      value: "80000"
-    - name: CODE_MAX_STRING_ARRAY_LENGTH
-      value: "30"
-    - name: CODE_MAX_OBJECT_ARRAY_LENGTH
-      value: "30"
-    - name: CODE_MAX_NUMBER_ARRAY_LENGTH
-      value: "1000"
 
   ## OpenTelemetry (OTEL) configuration
   otel:

--- a/ci/values/values-eso.yaml
+++ b/ci/values/values-eso.yaml
@@ -111,20 +111,6 @@ api:
       # Won't check for updates if left empty
       #   value: https://updates.dify.ai
       value: ""
-    - name: CODE_MAX_NUMBER
-      value: "9223372036854775807"
-    - name: CODE_MIN_NUMBER
-      value: "-9223372036854775808"
-    - name: CODE_MAX_STRING_LENGTH
-      value: "80000"
-    - name: TEMPLATE_TRANSFORM_MAX_LENGTH
-      value: "80000"
-    - name: CODE_MAX_STRING_ARRAY_LENGTH
-      value: "30"
-    - name: CODE_MAX_OBJECT_ARRAY_LENGTH
-      value: "30"
-    - name: CODE_MAX_NUMBER_ARRAY_LENGTH
-      value: "1000"
 
   ## OpenTelemetry (OTEL) configuration
   otel:

--- a/ci/values/values-legacy-external-all.yaml
+++ b/ci/values/values-legacy-external-all.yaml
@@ -111,20 +111,6 @@ api:
       # Won't check for updates if left empty
       #   value: https://updates.dify.ai
       value: ""
-    - name: CODE_MAX_NUMBER
-      value: "9223372036854775807"
-    - name: CODE_MIN_NUMBER
-      value: "-9223372036854775808"
-    - name: CODE_MAX_STRING_LENGTH
-      value: "80000"
-    - name: TEMPLATE_TRANSFORM_MAX_LENGTH
-      value: "80000"
-    - name: CODE_MAX_STRING_ARRAY_LENGTH
-      value: "30"
-    - name: CODE_MAX_OBJECT_ARRAY_LENGTH
-      value: "30"
-    - name: CODE_MAX_NUMBER_ARRAY_LENGTH
-      value: "1000"
   service:
     port: 5001
     annotations: {}

--- a/ci/values/values-legacy-external-mysql-all.yaml
+++ b/ci/values/values-legacy-external-mysql-all.yaml
@@ -111,20 +111,6 @@ api:
       # Won't check for updates if left empty
       #   value: https://updates.dify.ai
       value: ""
-    - name: CODE_MAX_NUMBER
-      value: "9223372036854775807"
-    - name: CODE_MIN_NUMBER
-      value: "-9223372036854775808"
-    - name: CODE_MAX_STRING_LENGTH
-      value: "80000"
-    - name: TEMPLATE_TRANSFORM_MAX_LENGTH
-      value: "80000"
-    - name: CODE_MAX_STRING_ARRAY_LENGTH
-      value: "30"
-    - name: CODE_MAX_OBJECT_ARRAY_LENGTH
-      value: "30"
-    - name: CODE_MAX_NUMBER_ARRAY_LENGTH
-      value: "1000"
   service:
     port: 5001
     annotations: {}

--- a/ci/values/values-legacy.yaml
+++ b/ci/values/values-legacy.yaml
@@ -115,20 +115,6 @@ api:
       # Won't check for updates if left empty
       #   value: https://updates.dify.ai
       value: ""
-    - name: CODE_MAX_NUMBER
-      value: "9223372036854775807"
-    - name: CODE_MIN_NUMBER
-      value: "-9223372036854775808"
-    - name: CODE_MAX_STRING_LENGTH
-      value: "80000"
-    - name: TEMPLATE_TRANSFORM_MAX_LENGTH
-      value: "80000"
-    - name: CODE_MAX_STRING_ARRAY_LENGTH
-      value: "30"
-    - name: CODE_MAX_OBJECT_ARRAY_LENGTH
-      value: "30"
-    - name: CODE_MAX_NUMBER_ARRAY_LENGTH
-      value: "1000"
 
   ## OpenTelemetry (OTEL) configuration
   otel:


### PR DESCRIPTION
## Summary

- Remove `CODE_MAX_*` from `api.extraEnv` in the default chart values and CI fixtures.
- These overrides were applied only to the API deployment, not the worker, which could cause inconsistent code execution limits between the two components.
- Rely on the Dify image defaults instead so API and worker behave the same out of the box; operators can still set these via `api.extraEnv` / `worker.extraEnv` if needed.