### PR TITLE
fix(ci): repair CVE scan workflow with trivy-action and reliable reporting

### DIFF
--- a/.github/workflows/cve-scan.yml
+++ b/.github/workflows/cve-scan.yml
@@ -13,7 +13,61 @@ permissions:
   security-events: write  # optional: for SARIF upload
 
 jobs:
-  cve-scan:
+  extract-images:
+    runs-on: ubuntu-latest
+    outputs:
+      images: ${{ steps.images.outputs.images }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Extract default images from chart
+        id: images
+        run: |
+          pip install --quiet pyyaml
+          images=$(python3 ci/scripts/extract-chart-images.py | jq -R -s -c 'split("\n") | map(select(length > 0))')
+          echo "images=${images}" >> "$GITHUB_OUTPUT"
+
+  scan-images:
+    needs: extract-images
+    if: needs.extract-images.outputs.images != '[]'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        image: ${{ fromJSON(needs.extract-images.outputs.images) }}
+    steps:
+      - name: Prepare result path
+        id: paths
+        run: |
+          safe=$(echo "${{ matrix.image }}" | tr '/:' '__')
+          mkdir -p trivy-results
+          echo "safe=${safe}" >> "$GITHUB_OUTPUT"
+          echo "output=trivy-results/${safe}.json" >> "$GITHUB_OUTPUT"
+
+      - name: Run Trivy on image
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: ${{ matrix.image }}
+          format: json
+          output: ${{ steps.paths.outputs.output }}
+          exit-code: '0'
+          timeout: 10m
+
+      - name: Upload scan result
+        uses: actions/upload-artifact@v4
+        with:
+          name: trivy-result-${{ steps.paths.outputs.safe }}
+          path: ${{ steps.paths.outputs.output }}
+
+  report:
+    needs: scan-images
+    if: ${{ always() && (needs.scan-images.result == 'success' || needs.scan-images.result == 'failure') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -24,33 +78,14 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Install Trivy
-        run: |
-          sudo apt-get update -qq && sudo apt-get install -y wget
-          TRIVY_VERSION="0.49.0"
-          wget -q "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz"
-          tar -xzf "trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" -C /usr/local/bin trivy
-          trivy --version
-
-      - name: Extract default images from chart
-        id: images
-        run: |
-          pip install --quiet pyyaml
-          python3 ci/scripts/extract-chart-images.py | tee image-list.txt
-          echo "count=$(wc -l < image-list.txt)" >> "$GITHUB_OUTPUT"
-
-      - name: Run Trivy on each image
-        if: steps.images.outputs.count != '0'
-        run: |
-          mkdir -p trivy-results
-          while IFS= read -r image; do
-            [ -z "$image" ] && continue
-            safe=$(echo "$image" | tr '/:' '__')
-            trivy image --format json --output "trivy-results/${safe}.json" --timeout 10m "$image" || true
-          done < image-list.txt
+      - name: Download scan results
+        uses: actions/download-artifact@v4
+        with:
+          pattern: trivy-result-*
+          merge-multiple: true
+          path: trivy-results
 
       - name: Generate CVE report
-        if: steps.images.outputs.count != '0'
         run: |
           app_version=$(grep -E '^appVersion:' charts/dify/Chart.yaml | sed -n 's/.*"\(.*\)".*/\1/p' || true)
           python3 ci/scripts/trivy-report-to-md.py trivy-results --version "${app_version:-unknown}" > cve-report.md
@@ -61,7 +96,6 @@ jobs:
           echo '```' >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload CVE report
-        if: steps.images.outputs.count != '0'
         uses: actions/upload-artifact@v4
         with:
           name: cve-report

--- a/.github/workflows/cve-scan.yml
+++ b/.github/workflows/cve-scan.yml
@@ -7,7 +7,7 @@ on:
     branches: [ master ]
     paths:
       - 'charts/dify/Chart.yaml'
-
+  workflow_dispatch:
 permissions:
   contents: read
   security-events: write  # optional: for SARIF upload


### PR DESCRIPTION
- Replace the broken manual Trivy v0.49.0 install with aquasecurity/trivy-action@v0.36.0, matrix per-image scans, and report job conditions that handle skipped and partially failed runs.
- Allow manual triggering of CVE scan