### PR TITLE
fix: preserve newline before dify.common.config

### DIFF
--- a/charts/dify/templates/config.tpl
+++ b/charts/dify/templates/config.tpl
@@ -28,7 +28,7 @@ TRIGGER_URL: {{ .Values.global.triggerDomain | quote }}
 {{- define "dify.api.config" -}}
 # Startup mode, 'api' starts the API server.
 MODE: api
-{{- include "dify.common.config" . }}
+{{ include "dify.common.config" . }}
 # A secret key that is used for securely signing the session cookie and encrypting sensitive information on the database. You can generate a strong key using `openssl rand -base64 42`.
 # SECRET_KEY: {{ .Values.global.appSecretKey }}
 
@@ -116,7 +116,7 @@ MODE: worker
 # The Celery worker for processing the queue.
 
 # --- All the configurations below are the same as those in the 'api' service. ---
-{{- include "dify.common.config" . }}
+{{ include "dify.common.config" . }}
 # A secret key that is used for securely signing the session cookie and encrypting sensitive information on the database. You can generate a strong key using `openssl rand -base64 42`.
 # same as the API service
 # SECRET_KEY: {{ .Values.global.appSecretKey }}


### PR DESCRIPTION
## Description

This PR fixes a YAML formatting issue in `charts/dify/templates/config.tpl` where the `MODE: api` value incorrectly merges with the subsequent comment during Helm rendering. 

## Motivation and Context

Currently, in the `dify.api.config` block, the inclusion of the common config uses a left-trimming whitespace control character (`{{-`):

```yaml
# Startup mode, 'api' starts the API server.
MODE: api
{{- include "dify.common.config" . }}
```

## Result
```yaml
MODE: api# The base URL of console application web frontend, refers to the Console
```

## Solution
I removed the left-trimming hyphen (-) from the include statement:
{{ include "dify.common.config" . }}

This ensures that the newline after MODE: api is correctly preserved, allowing the common config comments and variables to start on a fresh line.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)