### PR TITLE
feat: add opt-in Gateway API HTTPRoute support to dify chart

### DIFF
--- a/charts/dify/templates/httproute.yaml
+++ b/charts/dify/templates/httproute.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.httproute.enabled -}}
+{{- $route := .Values.httproute -}}
+{{- $serviceName := include "dify.fullname" . -}}
+{{- $servicePort := .Values.service.port -}}
+apiVersion: {{ $route.apiVersion | default "gateway.networking.k8s.io/v1" }}
+kind: HTTPRoute
+metadata:
+  name: {{ template "dify.fullname" . }}
+  labels:
+    {{- include "dify.labels" . | nindent 4 }}
+    {{- with $route.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with $route.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with $route.parentRefs }}
+  parentRefs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $route.hostnames }}
+  hostnames:
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- with $route.additionalRules }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
+    {{- end }}
+    - backendRefs:
+        - name: {{ $serviceName }}
+          port: {{ $servicePort }}
+      {{- with $route.matches }}
+      matches:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $route.filters }}
+      filters:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end -}}

--- a/charts/dify/values.yaml
+++ b/charts/dify/values.yaml
@@ -1636,6 +1636,38 @@ ingress:
   #    hosts:
   #      - dify-example.local
 
+httproute:
+  # Create an HTTPRoute (Gateway API) to expose Dify as an alternative to
+  # Ingress. Requires the Gateway API CRDs to be installed in the cluster
+  # (https://gateway-api.sigs.k8s.io/). Disabled by default; enabling it does
+  # not affect the existing ingress above.
+  enabled: false
+  # HTTPRoute apiVersion (defaults to "gateway.networking.k8s.io/v1" when empty)
+  apiVersion: ""
+  annotations: {}
+  labels: {}
+  # parentRefs reference the Gateway(s) this HTTPRoute is attached to
+  # parentRefs:
+  #   - name: my-gateway
+  #     namespace: gateway-system
+  #     sectionName: http
+  parentRefs: []
+  # hostnames matched against the HTTP Host header to select this route
+  # hostnames:
+  #   - dify-example.local
+  hostnames: []
+  # matches define conditions used to match incoming requests against the rule.
+  # Defaults to a PathPrefix "/" match (mirrors the Ingress behavior above).
+  matches:
+    - path:
+        type: PathPrefix
+        value: /
+  # filters applied to requests that match this rule
+  filters: []
+  # additionalRules (templated) prepends custom HTTPRoute rules before the
+  # default single-backend rule above
+  additionalRules: []
+
 # Global node selector
 # If set, this will apply to all dify components
 # Individual components can be set to a different node selector


### PR DESCRIPTION
Adds an opt-in HTTPRoute (Gateway API) template so Dify can be exposed via a
Gateway as an alternative to Ingress. Disabled by default
(httproute.enabled: false); the existing ingress block is untouched, so current
users are unaffected. Requires the Gateway API CRDs in the cluster.

Dify fronts all components with an internal nginx proxy exposing a single
Service, so the route needs just one backendRef (the proxy Service on
service.port), mirroring the Ingress backend.

Validation (local):
- helm template: renders nothing when disabled (default), a valid HTTPRoute when enabled, and coexists with Ingress when both are enabled
- ct lint --charts charts/dify: passed
- ci/scripts/check_unused_values.py: no unused values
- helm lint: passed

I did not bump Chart.yaml (ct.yaml has check-version-increment: false and the
release workflow is maintainer-gated), so the version bump is left for the
release. Happy to trim the config surface (e.g. drop additionalRules/apiVersion)
if you prefer to keep it more minimal.

related: #398
