### PR TITLE
docs: add Agent Stub, /files, and Plugin inner API edges to network diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,11 @@ graph TB
     APIPod -.->|Agent runs| AgentBackendService
     WorkerPod -.->|Agent runs| AgentBackendService
     AgentBackendPod -.->|Shell execution| LocalSandboxService
+    LocalSandboxPod -.->|Agent Stub (/agent-stub)| AgentBackendService
+    LocalSandboxPod -.->|Signed file URLs (/files)| APIService
     AgentBackendPod -.->|Plugin invoke| PluginService
     AgentBackendPod -.->|Internal API| APIService
+    PluginPod -.->|Plugin internal API| APIService
 
     %% Data Layer - Databases
     subgraph DataLayer [🗄️ Data Layer]


### PR DESCRIPTION
## Summary
- Document Local Sandbox → Agent Backend (`/agent-stub`) and Local Sandbox → API (`/files`) reverse edges
- Document Plugin Daemon → API inner API calls
- Note that `/files` egress may later go via `agent_ssrf_proxy`; Local Sandbox stays internal-only