### PR TITLE
feat: add optional apiWebsocket for workflow collaboration

### DIFF
--- a/charts/dify/templates/_helpers.tpl
+++ b/charts/dify/templates/_helpers.tpl
@@ -47,6 +47,13 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{ template "dify.fullname" . }}-beat
 {{- end -}}
 
+{{/*
+Create a default fully qualified api-websocket name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "dify.apiWebsocket.fullname" -}}
+{{ template "dify.fullname" . }}-api-websocket
+{{- end -}}
 
 {{/*
 Create a default fully qualified web name.
@@ -206,6 +213,16 @@ Create the name of the service account to use for the celery beat
 {{- end -}}
 {{- end -}}
 
+{{/*
+Create the name of the service account to use for the api-websocket pod
+*/}}
+{{- define "dify.apiWebsocket.serviceAccountName" -}}
+{{- if .Values.apiWebsocket.serviceAccount.create -}}
+    {{ default (include "dify.apiWebsocket.fullname" .) .Values.apiWebsocket.serviceAccount.name | trunc 63 | trimSuffix "-" }}
+{{- else -}}
+    {{ default "default" .Values.apiWebsocket.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
 
 {{/*
 Create the name of the service account to use for the Dify Plugin Daemon

--- a/charts/dify/templates/api-websocket-deployment.yaml
+++ b/charts/dify/templates/api-websocket-deployment.yaml
@@ -1,0 +1,156 @@
+{{- if and .Values.apiWebsocket.enabled .Values.api.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    {{- include "dify.ud.annotations" . | nindent 4 }}
+    descriptions: api-websocket
+  labels:
+    {{- include "dify.labels" . | nindent 4 }}
+    component: api-websocket
+    # app: {{ template "dify.apiWebsocket.fullname" . }}
+    {{- include "dify.ud.labels" . | nindent 4 }}
+  name: {{ template "dify.apiWebsocket.fullname" . }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "dify.selectorLabels" . | nindent 6 }}
+      component: api-websocket
+      {{/*
+      # Required labels for istio
+      # app: {{ template "dify.apiWebsocket.fullname" . }}
+      # version: {{ .Values.istioServiceMesh.version | quote }}
+      */}}
+  {{- if .Values.apiWebsocket.updateStrategy }}
+  strategy: {{- toYaml .Values.apiWebsocket.updateStrategy | nindent 4 }}
+  {{- end }}
+  template:
+    metadata:
+      annotations:
+        checksum/api-config: {{ include (print $.Template.BasePath "/api-config.yaml") . | sha256sum }}
+        checksum/api-secret: {{ include (print $.Template.BasePath "/api-secret.yaml") . | sha256sum }}
+        {{- include "dify.ud.annotations" . | nindent 8 }}
+      labels:
+        {{- include "dify.selectorLabels" . | nindent 8 }}
+        component: api-websocket
+        {{/*
+        # Required labels for istio
+        # app: {{ template "dify.apiWebsocket.fullname" . }}
+        # version: {{ .Values.istioServiceMesh.version | quote }}
+        */}}
+        {{- include "dify.ud.labels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "dify.apiWebsocket.serviceAccountName" . }}
+      {{- if .Values.apiWebsocket.priorityClassName }}
+      priorityClassName: {{ .Values.apiWebsocket.priorityClassName | quote }}
+      {{- end }}
+      {{- if .Values.apiWebsocket.shareProcessNamespace }}
+      shareProcessNamespace: {{ .Values.apiWebsocket.shareProcessNamespace }}
+      {{- end }}
+      {{- if eq .Release.Name "dify"}}
+      {{/*
+      Disable service environment variables,
+      otherwise they will clash with `DIFY_PORT` which is needed in entrypoint.sh
+      */}}
+      enableServiceLinks: false
+      {{- end }}
+      {{- if .Values.image.api.pullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.image.api.pullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
+      {{- if .Values.apiWebsocket.hostAliases }}
+      hostAliases:
+        {{- toYaml .Values.apiWebsocket.hostAliases | nindent 8 }}
+      {{- end }}
+      {{- if .Values.apiWebsocket.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.apiWebsocket.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
+      containers:
+        - image: "{{ .Values.image.api.repository }}:{{ default .Chart.AppVersion .Values.image.api.tag }}"
+          imagePullPolicy: "{{ .Values.image.api.pullPolicy }}"
+          name: api-websocket
+          {{- if .Values.apiWebsocket.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.apiWebsocket.customLivenessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.apiWebsocket.livenessProbe.enabled }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.apiWebsocket.livenessProbe "enabled") "context" $) | nindent 12 }}
+            httpGet:
+              path: /health
+              port: api
+          {{- end }}
+          {{- if .Values.apiWebsocket.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.apiWebsocket.customReadinessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.apiWebsocket.readinessProbe.enabled }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.apiWebsocket.readinessProbe "enabled") "context" $) | nindent 12 }}
+            httpGet:
+              path: /health
+              port: api
+          {{- end }}
+          {{- if .Values.apiWebsocket.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.apiWebsocket.customStartupProbe "context" $) | nindent 12 }}
+          {{- else if .Values.apiWebsocket.startupProbe.enabled }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.apiWebsocket.startupProbe "enabled") "context" $) | nindent 12 }}
+            tcpSocket:
+              port: api
+          {{- end }}
+          {{- if .Values.apiWebsocket.containerSecurityContext.enabled }}
+          securityContext: {{- omit .Values.apiWebsocket.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
+          env:
+            - name: MIGRATION_ENABLED
+              value: "false"
+            - name: SERVER_WORKER_AMOUNT
+              value: "1"
+            - name: SERVER_WORKER_CLASS
+              value: "geventwebsocket.gunicorn.workers.GeventWebSocketWorker"
+            - name: LOG_LEVEL
+              value: {{ .Values.apiWebsocket.logLevel | quote }}
+            {{- if .Values.apiWebsocket.extraEnv }}
+              {{- toYaml .Values.apiWebsocket.extraEnv | nindent 12 }}
+            {{- end }}
+          envFrom:
+            - configMapRef:
+                name: {{ template "dify.api.fullname" . }}
+            - secretRef:
+                name: {{ template "dify.api.fullname" . }}
+          ports:
+            - name: api
+              containerPort: 5001
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.apiWebsocket.resources | nindent 14 }}
+          {{- if .Values.apiWebsocket.extraVolumeMounts }}
+          volumeMounts:
+            {{- include "common.tplvalues.render" (dict "value" .Values.apiWebsocket.extraVolumeMounts "context" $) | nindent 12 }}
+          {{- end }}
+    {{- if and (.Values.nodeSelector) (not .Values.apiWebsocket.nodeSelector) }}
+      nodeSelector:
+        {{- toYaml .Values.nodeSelector | nindent 8 }}
+    {{- end }}
+    {{- if .Values.apiWebsocket.nodeSelector }}
+      nodeSelector:
+        {{- toYaml .Values.apiWebsocket.nodeSelector | nindent 8 }}
+    {{- end }}
+    {{- if and (.Values.affinity) (not .Values.apiWebsocket.affinity) }}
+      affinity:
+        {{- toYaml .Values.affinity | nindent 8 }}
+    {{- end }}
+    {{- if .Values.apiWebsocket.affinity }}
+      affinity:
+        {{- toYaml .Values.apiWebsocket.affinity | nindent 8 }}
+    {{- end }}
+    {{- if and (.Values.tolerations) (not .Values.apiWebsocket.tolerations) }}
+      tolerations:
+        {{- toYaml .Values.tolerations | nindent 8 }}
+    {{- end }}
+    {{- if .Values.apiWebsocket.tolerations }}
+      tolerations:
+        {{- toYaml .Values.apiWebsocket.tolerations | nindent 8 }}
+    {{- end }}
+      {{- if .Values.apiWebsocket.extraVolumes }}
+      volumes:
+        {{- include "common.tplvalues.render" (dict "value" .Values.apiWebsocket.extraVolumes "context" $) | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/dify/templates/api-websocket-deployment.yaml
+++ b/charts/dify/templates/api-websocket-deployment.yaml
@@ -12,7 +12,7 @@ metadata:
     {{- include "dify.ud.labels" . | nindent 4 }}
   name: {{ template "dify.apiWebsocket.fullname" . }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.apiWebsocket.replicas }}
   selector:
     matchLabels:
       {{- include "dify.selectorLabels" . | nindent 6 }}

--- a/charts/dify/templates/api-websocket-service-account.yaml
+++ b/charts/dify/templates/api-websocket-service-account.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.apiWebsocket.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "dify.apiWebsocket.serviceAccountName" . }}
+  labels: {{- include "dify.labels" . | nindent 4 }}
+    component: api-websocket
+  {{- if or .Values.apiWebsocket.serviceAccount.annotations (include "dify.ud.annotations" .) }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.apiWebsocket.serviceAccount.annotations (include "dify.ud.annotations" .) ) "context" . ) }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.apiWebsocket.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/charts/dify/templates/api-websocket-svc.yaml
+++ b/charts/dify/templates/api-websocket-svc.yaml
@@ -1,0 +1,29 @@
+{{- if and .Values.apiWebsocket.enabled .Values.api.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "dify.apiWebsocket.fullname" . }}
+  labels:
+    {{- include "dify.labels" . | nindent 4 }}
+    {{- if .Values.apiWebsocket.service.labels }}
+    {{- toYaml .Values.apiWebsocket.service.labels | nindent 4 }}
+    {{- end }}
+    component: "api-websocket"
+  {{- with .Values.apiWebsocket.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: ClusterIP
+  {{- if .Values.apiWebsocket.service.clusterIP }}
+  clusterIP: {{ .Values.apiWebsocket.service.clusterIP }}
+  {{- end }}
+  ports:
+    - name: http-api
+      port: {{ .Values.apiWebsocket.service.port }}
+      protocol: TCP
+      targetPort: api
+  selector:
+    {{- include "dify.selectorLabels" . | nindent 4 }}
+    component: "api-websocket"
+{{- end }}

--- a/charts/dify/templates/config.tpl
+++ b/charts/dify/templates/config.tpl
@@ -107,6 +107,9 @@ OTEL_METRIC_EXPORT_INTERVAL: {{ .Values.api.otel.metricExportInterval | toString
 OTEL_BATCH_EXPORT_TIMEOUT: {{ .Values.api.otel.batchExportTimeout | toString | quote }}
 OTEL_METRIC_EXPORT_TIMEOUT: {{ .Values.api.otel.metricExportTimeout | toString | quote }}
 {{- end }}
+{{- if .Values.apiWebsocket.enabled }}
+ENABLE_COLLABORATION_MODE: "true"
+{{- end }}
 {{- end }}
 
 {{- define "dify.worker.config" -}}
@@ -189,6 +192,9 @@ MARKETPLACE_API_URL: "/marketplace"
 {{- include "dify.marketplace.config" . }}
 {{- end }}
 MARKETPLACE_URL: {{ .Values.global.marketplace.url | quote }}
+{{- if .Values.apiWebsocket.enabled }}
+NEXT_PUBLIC_SOCKET_URL: {{ .Values.apiWebsocket.socketUrl | quote }}
+{{- end }}
 {{- end }}
 
 {{- define "dify.db.config" -}}
@@ -639,6 +645,16 @@ server {
       proxy_pass http://{{ template "dify.api.fullname" .}}:{{ .Values.api.service.port }};
       include proxy.conf;
     }
+
+    {{- if .Values.apiWebsocket.enabled }}
+    location /socket.io/ {
+      proxy_pass http://{{ template "dify.apiWebsocket.fullname" . }}:{{ .Values.apiWebsocket.service.port }};
+      include proxy.conf;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection "upgrade";
+      proxy_cache_bypass $http_upgrade;
+    }
+    {{- end }}
 
     location / {
       proxy_pass http://{{ template "dify.web.fullname" .}}:{{ .Values.web.service.port }};

--- a/charts/dify/templates/config.tpl
+++ b/charts/dify/templates/config.tpl
@@ -111,9 +111,7 @@ OTEL_METRIC_EXPORT_INTERVAL: {{ .Values.api.otel.metricExportInterval | toString
 OTEL_BATCH_EXPORT_TIMEOUT: {{ .Values.api.otel.batchExportTimeout | toString | quote }}
 OTEL_METRIC_EXPORT_TIMEOUT: {{ .Values.api.otel.metricExportTimeout | toString | quote }}
 {{- end }}
-{{- if .Values.apiWebsocket.enabled }}
-ENABLE_COLLABORATION_MODE: "true"
-{{- end }}
+ENABLE_COLLABORATION_MODE: {{ .Values.apiWebsocket.enabled | quote }}
 {{- end }}
 
 {{- define "dify.worker.config" -}}

--- a/charts/dify/values.schema.json
+++ b/charts/dify/values.schema.json
@@ -359,6 +359,69 @@
         }
       }
     },
+    "apiWebsocket": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "socketUrl": { "type": "string" },
+        "resources": { "type": "object" },
+        "nodeSelector": { "type": "object" },
+        "affinity": { "type": "object" },
+        "tolerations": { "type": "array" },
+        "priorityClassName": { "type": "string" },
+        "shareProcessNamespace": { "type": "boolean" },
+        "customLivenessProbe": { "type": "object" },
+        "customReadinessProbe": { "type": "object" },
+        "customStartupProbe": { "type": "object" },
+        "updateStrategy": {
+          "type": "object",
+          "properties": {
+            "type": { "type": "string" }
+          }
+        },
+        "hostAliases": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "ip": { "type": "string" },
+              "hostnames": {
+                "type": "array",
+                "items": { "type": "string" }
+              }
+            },
+            "required": ["ip", "hostnames"]
+          }
+        },
+        "podSecurityContext": { "type": "object" },
+        "containerSecurityContext": { "type": "object" },
+        "extraEnv": { "type": ["array", "null"] },
+        "logLevel": { "type": "string" },
+        "extraVolumes": { "type": "array" },
+        "extraVolumeMounts": { "type": "array" },
+        "livenessProbe": { "type": "object" },
+        "readinessProbe": { "type": "object" },
+        "startupProbe": { "type": "object" },
+        "service": {
+          "type": "object",
+          "properties": {
+            "port": { "type": "integer" },
+            "annotations": { "type": "object" },
+            "labels": { "type": "object" },
+            "clusterIP": { "type": "string" }
+          }
+        },
+        "serviceAccount": {
+          "type": "object",
+          "properties": {
+            "create": { "type": "boolean" },
+            "name": { "type": "string" },
+            "automountServiceAccountToken": { "type": "boolean" },
+            "annotations": { "type": "object" }
+          }
+        }
+      }
+    },
     "proxy": {
       "type": "object",
       "properties": {

--- a/charts/dify/values.schema.json
+++ b/charts/dify/values.schema.json
@@ -386,6 +386,7 @@
       "properties": {
         "enabled": { "type": "boolean" },
         "socketUrl": { "type": "string" },
+        "replicas": { "type": "integer" },
         "resources": { "type": "object" },
         "nodeSelector": { "type": "object" },
         "affinity": { "type": "object" },

--- a/charts/dify/values.yaml
+++ b/charts/dify/values.yaml
@@ -477,6 +477,68 @@ beat:
     ##
     annotations: {}
 
+apiWebsocket:
+  enabled: false
+  # Public WebSocket URL for browser clients (NEXT_PUBLIC_SOCKET_URL).
+  # Example: wss://your-domain
+  socketUrl: ""
+  resources: {}
+  nodeSelector: {}
+  affinity: {}
+  tolerations: []
+  priorityClassName: ""
+  ## @param apiWebsocket.shareProcessNamespace Share a single process namespace between all containers in api-websocket pods
+  shareProcessNamespace: false
+  ## Configure extra options for api-websocket containers' liveness, readiness, and startup probes
+  customLivenessProbe: {}
+  customReadinessProbe: {}
+  customStartupProbe: {}
+  ## @param apiWebsocket.updateStrategy Update strategy type and configuration parameters
+  updateStrategy:
+    type: Recreate
+  hostAliases: []
+  podSecurityContext:
+    enabled: true
+    fsGroup: 1001
+  containerSecurityContext:
+    enabled: true
+    runAsUser: 1001
+  extraEnv: []
+  logLevel: INFO
+  extraVolumes: []
+  extraVolumeMounts: []
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 30
+    periodSeconds: 30
+    timeoutSeconds: 5
+    failureThreshold: 5
+    successThreshold: 1
+  readinessProbe:
+    enabled: true
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 5
+    successThreshold: 1
+  startupProbe:
+    enabled: false
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 5
+    successThreshold: 1
+  service:
+    port: 5001
+    annotations: {}
+    labels: {}
+    clusterIP: ""
+  serviceAccount:
+    create: false
+    name: ""
+    automountServiceAccountToken: false
+    annotations: {}
+
 proxy:
   enabled: true
   replicas: 1

--- a/charts/dify/values.yaml
+++ b/charts/dify/values.yaml
@@ -496,6 +496,7 @@ apiWebsocket:
   # Public WebSocket URL for browser clients (NEXT_PUBLIC_SOCKET_URL).
   # Example: wss://your-domain
   socketUrl: ""
+  replicas: 1
   resources: {}
   nodeSelector: {}
   affinity: {}
@@ -508,8 +509,8 @@ apiWebsocket:
   customReadinessProbe: {}
   customStartupProbe: {}
   ## @param apiWebsocket.updateStrategy Update strategy type and configuration parameters
-  updateStrategy:
-    type: Recreate
+  ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
+  updateStrategy: {}
   hostAliases: []
   podSecurityContext:
     enabled: true


### PR DESCRIPTION
## Summary
- Add an optional `apiWebsocket` component (disabled by default) that runs the API image with Gevent WebSocket workers for workflow collaboration.
- Wire nginx `/socket.io/`, set `ENABLE_COLLABORATION_MODE` from `apiWebsocket.enabled`, and expose `NEXT_PUBLIC_SOCKET_URL` when enabled.
- Make `apiWebsocket.replicas` configurable with a rolling update strategy, matching the api component.
