### PR TITLE
fix(ci): cover agentBackend/localSandbox in image prep and fix redis tag

### DIFF
--- a/ci/scripts/extract-chart-images.py
+++ b/ci/scripts/extract-chart-images.py
@@ -8,8 +8,8 @@ from pathlib import Path
 import sys
 import yaml
 
-# Keys that use Chart.AppVersion as default tag in templates (api, web, pluginDaemon)
-APPVERSION_KEYS = ("api", "web", "pluginDaemon")
+# Keys that use Chart.AppVersion as default tag in templates
+APPVERSION_KEYS = ("api", "web", "pluginDaemon", "agentBackend", "localSandbox")
 
 def main():
     repo_root = Path(__file__).resolve().parents[2]
@@ -33,7 +33,7 @@ def main():
     image_config = values.get("image") or {}
 
     images = []
-    for key in ("api", "web", "sandbox", "proxy", "ssrfProxy", "pluginDaemon"):
+    for key in ("api", "web", "sandbox", "proxy", "ssrfProxy", "pluginDaemon", "agentBackend", "localSandbox"):
         block = image_config.get(key)
         if not block:
             continue

--- a/ci/scripts/extract-images.sh
+++ b/ci/scripts/extract-images.sh
@@ -55,7 +55,7 @@ DIFY_IMAGES=(
     "$LOCAL_SANDBOX_IMAGE"
 )
 
-# Common dependency images (redis tag matches charts/dify/values.yaml default)
+# Common dependency images
 DEPENDENCY_IMAGES=(
     "bitnamilegacy/postgresql:15.3.0-debian-11-r7"
     "bitnamilegacy/redis:7.0.11-debian-11-r12"

--- a/ci/scripts/extract-images.sh
+++ b/ci/scripts/extract-images.sh
@@ -35,6 +35,14 @@ PLUGIN_DAEMON_REPO=$(grep -A1 "pluginDaemon:" "ci/values/$VALUES_FILE" | grep "r
 PLUGIN_DAEMON_TAG=$(grep -A2 "pluginDaemon:" "ci/values/$VALUES_FILE" | grep "tag:" | awk '{print $2}' | head -1 | tr -d '"')
 PLUGIN_DAEMON_IMAGE="$PLUGIN_DAEMON_REPO:$PLUGIN_DAEMON_TAG"
 
+AGENT_BACKEND_REPO=$(grep -A1 "agentBackend:" "ci/values/$VALUES_FILE" | grep "repository:" | awk '{print $2}' | head -1)
+AGENT_BACKEND_TAG=$(grep -A2 "agentBackend:" "ci/values/$VALUES_FILE" | grep "tag:" | awk '{print $2}' | head -1 | tr -d '"')
+AGENT_BACKEND_IMAGE="$AGENT_BACKEND_REPO:$AGENT_BACKEND_TAG"
+
+LOCAL_SANDBOX_REPO=$(grep -A1 "localSandbox:" "ci/values/$VALUES_FILE" | grep "repository:" | awk '{print $2}' | head -1)
+LOCAL_SANDBOX_TAG=$(grep -A2 "localSandbox:" "ci/values/$VALUES_FILE" | grep "tag:" | awk '{print $2}' | head -1 | tr -d '"')
+LOCAL_SANDBOX_IMAGE="$LOCAL_SANDBOX_REPO:$LOCAL_SANDBOX_TAG"
+
 # Collect all Dify application images
 DIFY_IMAGES=(
     "$API_IMAGE"
@@ -43,12 +51,14 @@ DIFY_IMAGES=(
     "$PROXY_IMAGE"
     "$SSRF_PROXY_IMAGE"
     "$PLUGIN_DAEMON_IMAGE"
+    "$AGENT_BACKEND_IMAGE"
+    "$LOCAL_SANDBOX_IMAGE"
 )
 
-# Common dependency images
+# Common dependency images (redis tag matches charts/dify/values.yaml default)
 DEPENDENCY_IMAGES=(
     "bitnamilegacy/postgresql:15.3.0-debian-11-r7"
-    "bitnamilegacy/redis:6.2.7-debian-11-r11"
+    "bitnamilegacy/redis:7.0.11-debian-11-r12"
     "bitnamilegacy/redis-sentinel:6.2.7-debian-11-r12"
     "bitnamilegacy/redis-exporter:1.43.0-debian-11-r4"
 )

--- a/ci/values/values-eso-external-s3-pg-es-redis.yaml
+++ b/ci/values/values-eso-external-s3-pg-es-redis.yaml
@@ -29,6 +29,16 @@ image:
     tag: 0.6.3-local
     pullPolicy: IfNotPresent
 
+  agentBackend:
+    repository: langgenius/dify-agent-backend
+    tag: "1.16.1"
+    pullPolicy: IfNotPresent
+
+  localSandbox:
+    repository: langgenius/dify-agent-local-sandbox
+    tag: "1.16.1"
+    pullPolicy: IfNotPresent
+
 api:
   enabled: true
   replicas: 1

--- a/ci/values/values-eso-otel.yaml
+++ b/ci/values/values-eso-otel.yaml
@@ -29,6 +29,16 @@ image:
     tag: 0.6.3-local
     pullPolicy: IfNotPresent
 
+  agentBackend:
+    repository: langgenius/dify-agent-backend
+    tag: "1.16.1"
+    pullPolicy: IfNotPresent
+
+  localSandbox:
+    repository: langgenius/dify-agent-local-sandbox
+    tag: "1.16.1"
+    pullPolicy: IfNotPresent
+
 api:
   enabled: true
   replicas: 1

--- a/ci/values/values-eso.yaml
+++ b/ci/values/values-eso.yaml
@@ -29,6 +29,16 @@ image:
     tag: 0.6.3-local
     pullPolicy: IfNotPresent
 
+  agentBackend:
+    repository: langgenius/dify-agent-backend
+    tag: "1.16.1"
+    pullPolicy: IfNotPresent
+
+  localSandbox:
+    repository: langgenius/dify-agent-local-sandbox
+    tag: "1.16.1"
+    pullPolicy: IfNotPresent
+
 api:
   enabled: true
   replicas: 1

--- a/ci/values/values-legacy-external-all.yaml
+++ b/ci/values/values-legacy-external-all.yaml
@@ -29,6 +29,16 @@ image:
     tag: 0.6.3-local
     pullPolicy: IfNotPresent
 
+  agentBackend:
+    repository: langgenius/dify-agent-backend
+    tag: "1.16.1"
+    pullPolicy: IfNotPresent
+
+  localSandbox:
+    repository: langgenius/dify-agent-local-sandbox
+    tag: "1.16.1"
+    pullPolicy: IfNotPresent
+
 api:
   enabled: true
   replicas: 1

--- a/ci/values/values-legacy-external-mysql-all.yaml
+++ b/ci/values/values-legacy-external-mysql-all.yaml
@@ -29,6 +29,16 @@ image:
     tag: 0.6.3-local
     pullPolicy: IfNotPresent
 
+  agentBackend:
+    repository: langgenius/dify-agent-backend
+    tag: "1.16.1"
+    pullPolicy: IfNotPresent
+
+  localSandbox:
+    repository: langgenius/dify-agent-local-sandbox
+    tag: "1.16.1"
+    pullPolicy: IfNotPresent
+
 api:
   enabled: true
   replicas: 1

--- a/ci/values/values-legacy.yaml
+++ b/ci/values/values-legacy.yaml
@@ -33,6 +33,16 @@ image:
     tag: 0.6.3-local
     pullPolicy: IfNotPresent
 
+  agentBackend:
+    repository: langgenius/dify-agent-backend
+    tag: "1.16.1"
+    pullPolicy: IfNotPresent
+
+  localSandbox:
+    repository: langgenius/dify-agent-local-sandbox
+    tag: "1.16.1"
+    pullPolicy: IfNotPresent
+
 api:
   enabled: true
   replicas: 1


### PR DESCRIPTION
## Summary
- Add `agentBackend` and `localSandbox` to CI image extraction and all CI values overlays
- Update pre-pulled redis tag to `7.0.11-debian-11-r12` to match chart defaults