### PR TITLE
fix(s3): stop emitting static keys when `externalS3.useIAM` is enabled

### DIFF
--- a/charts/dify/templates/credentials.tpl
+++ b/charts/dify/templates/credentials.tpl
@@ -79,9 +79,11 @@ DB_PASSWORD: {{ .password | b64enc | quote }}
 {{- end }}
 
 {{- define "dify.storage.credentials" -}}
-{{- if and .Values.externalS3.enabled (not .Values.externalSecret.enabled)}}
+{{- if .Values.externalS3.enabled }}
+{{- if and (not .Values.externalSecret.enabled) (not .Values.externalS3.useIAM) }}
 S3_ACCESS_KEY: {{ .Values.externalS3.accessKey | b64enc | quote }}
 S3_SECRET_KEY: {{ .Values.externalS3.secretKey | b64enc | quote }}
+{{- end }}
 {{- else if .Values.externalAzureBlobStorage.enabled }}
 # The Azure Blob storage configurations, only available when STORAGE_TYPE is `azure-blob`.
 AZURE_BLOB_ACCOUNT_KEY: {{ .Values.externalAzureBlobStorage.key | b64enc | quote }}
@@ -287,8 +289,10 @@ DIFY_INNER_API_KEY: {{ .Values.api.auth.internalApiKey | default .Values.global.
 
 {{- define "dify.pluginDaemon.storage.credentials" -}}
 {{- if and .Values.externalS3.enabled .Values.externalS3.bucketName.pluginDaemon }}
+{{- if not .Values.externalS3.useIAM }}
 AWS_ACCESS_KEY: {{ .Values.externalS3.accessKey | b64enc | quote }}
 AWS_SECRET_KEY: {{ .Values.externalS3.secretKey | b64enc | quote }}
+{{- end }}
 {{- else if .Values.externalAzureBlobStorage.enabled }}
   {{- with .Values.externalAzureBlobStorage }}
     {{- $protocol := "" }}


### PR DESCRIPTION
## What

Do not render `S3_ACCESS_KEY`/`S3_SECRET_KEY` (api, worker) and `AWS_ACCESS_KEY`/`AWS_SECRET_KEY` (plugin daemon) when `externalS3.useIAM: true`.

## Why

`externalS3.useIAM: true` means "there is no static credential here, authenticate with the instance/pod role". The chart still materialises the `externalS3.accessKey` / `externalS3.secretKey` defaults in the component Secrets:

```
dify-api / dify-worker  → S3_ACCESS_KEY = "ak-difyai"   S3_SECRET_KEY = "sk-difyai"
dify-plugin-daemon      → AWS_ACCESS_KEY = "ak-difyai"  AWS_SECRET_KEY = "sk-difyai"
```

To be precise about the impact — the current code does ignore them:

- `api`/`worker`: `aws_s3_storage.py` branches on `S3_USE_AWS_MANAGED_IAM` and builds the client from `boto3.Session()`, never reading `S3_ACCESS_KEY`;
- `pluginDaemon`: `dify-cloud-kit`'s `NewS3Storage` short-circuits with `if (ak == "" && sk == "") || useIamRole` (added in [`1b8f6a1`](https://github.com/langgenius/dify-cloud-kit/commit/1b8f6a17), Jun 2025).

So this is hygiene rather than a broken-today bug, and it is worth fixing for two reasons:

1. **Placeholder credentials where no credential should exist.** They sit in the Secret, in the effective environment (`kubectl exec … env`), and in every backup/replica of that Secret — for a deployment whose whole point was not to hold a static key.
2. **The guarantee is one SDK change away.** Correctness relies on every client keeping the IAM flag ahead of a static credential; the daemon only gained the `|| useIamRole` short-circuit in mid-2025. Not emitting the keys removes the dependency instead of relying on it. It also removes a silent trap: flipping `useIAM` back to `false` without setting real keys resurrects `ak-difyai` and fails against a real backend with a confusing signature error rather than a missing-credential one.

## How

Nest the credential lines under `not .Values.externalS3.useIAM`, keeping the surrounding storage-backend `if/else if` chain intact. Key-based installs (`useIAM: false`, the default) render byte-identically.

## Test

```bash
# useIAM: true  → no S3/AWS credential keys in any Secret
helm template t charts/dify -f values.yaml | grep -E "S3_ACCESS_KEY|AWS_ACCESS_KEY"

# useIAM: false → unchanged
helm template t charts/dify -f values.yaml --set externalS3.useIAM=false | grep -E "S3_ACCESS_KEY|AWS_ACCESS_KEY"

helm lint charts/dify -f values.yaml
python3 ci/scripts/check_unused_values.py --skip-section redis --skip-section postgresql --skip-section weaviate --skip-section externalSecret
```

Found while deploying the chart (`0.37.0`) on EKS with IRSA; re-validated against `master` (`0.38.0-rc1`).
