### PR TITLE
fix(s3): propagate externalS3.pathStyle to api/worker via S3_ADDRESS_STYLE

### DIFF
--- a/charts/dify/templates/config.tpl
+++ b/charts/dify/templates/config.tpl
@@ -249,6 +249,9 @@ S3_BUCKET_NAME: {{ .Values.externalS3.bucketName.api | quote }}
 # S3_ACCESS_KEY: {{ .Values.externalS3.accessKey | quote }}
 # S3_SECRET_KEY: {{ .Values.externalS3.secretKey | quote }}
 S3_REGION: {{ .Values.externalS3.region | quote }}
+# Addressing style used by `api`/`worker` (boto3), counterpart of `S3_USE_PATH_STYLE` in `pluginDaemon`.
+# `path` when `externalS3.pathStyle` is enabled, `auto` (boto3 default) otherwise.
+S3_ADDRESS_STYLE: {{ if .Values.externalS3.pathStyle }}"path"{{ else }}"auto"{{ end }}
 S3_USE_AWS_MANAGED_IAM: {{ .Values.externalS3.useIAM | toString | quote }}
 {{- else if .Values.externalAzureBlobStorage.enabled }}
 # The type of storage to use for storing user files. Supported values are `local`, `s3`, `azure-blob`, `aliyun-oss` and `google-storage`, Default: `local`

--- a/charts/dify/values.yaml
+++ b/charts/dify/values.yaml
@@ -3202,6 +3202,10 @@ externalRedis:
 externalS3:
   enabled: false
   endpoint: "https://xxx.r2.cloudflarestorage.com"
+  # Use path-style addressing (`https://<endpoint>/<bucket>/<key>`) instead of virtual-hosted style
+  # (`https://<bucket>.<endpoint>/<key>`). Required by most S3-compatible backends (e.g. MinIO), and by
+  # AWS S3 when the bucket name is not DNS-compatible (e.g. contains dots, which breaks TLS validation).
+  # Applies to `api`/`worker` (`S3_ADDRESS_STYLE`) and to `pluginDaemon` (`S3_USE_PATH_STYLE`).
   pathStyle: false
   accessKey: "ak-difyai"
   secretKey: "sk-difyai"


### PR DESCRIPTION
## What

Render `S3_ADDRESS_STYLE` in the `api` and `worker` ConfigMaps from the existing `externalS3.pathStyle` value.

## Why

`externalS3.pathStyle` is currently rendered **only** for `pluginDaemon`, as `S3_USE_PATH_STYLE`. The `api` and `worker` ConfigMaps receive no equivalent variable, so an operator who sets `pathStyle: true` gets it honoured by one of the three S3 consumers and silently ignored by the other two.

Rendered with `externalS3.pathStyle: true` before this change:

```
dify-api           → S3_ENDPOINT, S3_BUCKET_NAME, S3_REGION, S3_USE_AWS_MANAGED_IAM
dify-worker        → S3_ENDPOINT, S3_BUCKET_NAME, S3_REGION, S3_USE_AWS_MANAGED_IAM
dify-plugin-daemon → S3_ENDPOINT, S3_USE_AWS_MANAGED_IAM, S3_USE_PATH_STYLE   ← only here
```

Dify does expose the equivalent knob for the Python side: `S3_ADDRESS_STYLE` (`auto` | `path` | `virtual`), declared in [`api/configs/middleware/storage/amazon_s3_storage_config.py`](https://github.com/langgenius/dify/blob/main/api/configs/middleware/storage/amazon_s3_storage_config.py) and consumed in [`api/extensions/storage/aws_s3_storage.py`](https://github.com/langgenius/dify/blob/main/api/extensions/storage/aws_s3_storage.py) through `Config(s3={"addressing_style": dify_config.S3_ADDRESS_STYLE})`.

Where it bites: buckets whose name contains a dot. In virtual-hosted style the URL becomes `my.bucket.s3.<region>.amazonaws.com`, and the extra label is not covered by the AWS wildcard certificate:

```
$ curl -I https://my.bucket.s3.us-east-1.amazonaws.com/
curl: (60) SSL: no alternative certificate subject name matches target host name

$ curl -I https://s3.us-east-1.amazonaws.com/my.bucket/
HTTP/1.1 403 Forbidden
x-amz-bucket-region: us-east-1          ← TLS fine
```

boto3's `auto` mode happens to pick path-style for such buckets, which masks the gap most of the time — but the declared option still does not reach the components.

## How

```yaml
S3_ADDRESS_STYLE: {{ if .Values.externalS3.pathStyle }}"path"{{ else }}"auto"{{ end }}
```

`auto` is boto3's own default, so **installs that leave `pathStyle: false` render an explicit value that matches today's behaviour** — no functional change for them. `pluginDaemon` keeps `S3_USE_PATH_STYLE` (that is the variable the Go daemon reads).

The `externalS3.pathStyle` comment in `values.yaml` now says what the flag does and which components it reaches.

## Known limitation (upstream `dify`, not this chart)

With `externalS3.useIAM: true`, `aws_s3_storage.py` takes the `boto3.Session().client("s3", region_name=...)` branch, which passes neither `endpoint_url` nor `addressing_style` — so `S3_ADDRESS_STYLE` is ignored in IAM mode by Dify itself. The variable is still correct to render (it is honoured in key-based mode, and costs nothing in IAM mode); fixing the IAM branch belongs in `langgenius/dify`.

## Test

```bash
helm template t charts/dify -f values.yaml --set externalS3.pathStyle=true  | grep S3_ADDRESS_STYLE   # → "path"  (api + worker)
helm template t charts/dify -f values.yaml --set externalS3.pathStyle=false | grep S3_ADDRESS_STYLE   # → "auto"  (api + worker)
helm lint charts/dify -f values.yaml
python3 ci/scripts/check_unused_values.py --skip-section redis --skip-section postgresql --skip-section weaviate --skip-section externalSecret
```
