### PR TITLE
Update NOTES for HTTPRoute access and optional nginx proxy

### DIFF
--- a/charts/dify/templates/NOTES.txt
+++ b/charts/dify/templates/NOTES.txt
@@ -1,24 +1,37 @@
-1. Get the application URL by running these commands:
 {{- if .Values.ingress.enabled }}
-{{- range $host := .Values.ingress.hosts }}
-  {{- range .paths }}
+1. Access the application at:
+  {{- range $host := .Values.ingress.hosts }}
+    {{- range .paths }}
   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+    {{- end }}
   {{- end }}
-{{- end }}
-{{- else if contains "NodePort" .Values.service.type }}
+{{- else if .Values.httproute.enabled }}
+  {{- $hostnames := compact (.Values.httproute.hostnames | default list) }}
+  {{- if $hostnames }}
+1. Access the application at:
+    {{- range $hostname := $hostnames }}
+  http://{{ tpl $hostname $ }}/
+    {{- end }}
+  {{- else }}
+1. Get the application URL by running these commands:
+  # HTTPRoute is enabled; access Dify via your Gateway listener and parentRefs.
+  kubectl get --namespace {{ .Release.Namespace }} httproute {{ include "dify.fullname" . }} -o yaml
+  {{- end }}
+{{- else if and .Values.proxy.enabled (or (contains "NodePort" .Values.service.type) (contains "LoadBalancer" .Values.service.type) (contains "ClusterIP" .Values.service.type)) }}
+1. Get the application URL by running these commands:
+  {{- if contains "NodePort" .Values.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "dify.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo http://$NODE_IP:$NODE_PORT
-{{- else if contains "LoadBalancer" .Values.service.type }}
-     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "dify.fullname" . }}'
+  {{- else if contains "LoadBalancer" .Values.service.type }}
+  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+        You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "dify.fullname" . }}'
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "dify.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
   echo http://$SERVICE_IP:{{ .Values.service.port }}
-{{- else if contains "ClusterIP" .Values.service.type }}
-{{- if .Values.proxy.enabled }}
+  {{- else if contains "ClusterIP" .Values.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "dify.name" . }},app.kubernetes.io/instance={{ .Release.Name }},component=proxy" -o jsonpath="{.items[0].metadata.name}")
   export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
   echo "Visit http://127.0.0.1:8080 to use your application"
   kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
-{{- end }}
+  {{- end }}
 {{- end }}

--- a/charts/dify/templates/httproute.yaml
+++ b/charts/dify/templates/httproute.yaml
@@ -1,7 +1,5 @@
 {{- if .Values.httproute.enabled -}}
 {{- $route := .Values.httproute -}}
-{{- $serviceName := include "dify.fullname" . -}}
-{{- $servicePort := .Values.service.port -}}
 apiVersion: {{ $route.apiVersion | default "gateway.networking.k8s.io/v1" }}
 kind: HTTPRoute
 metadata:
@@ -28,9 +26,10 @@ spec:
     {{- with $route.additionalRules }}
     {{- tpl (toYaml .) $ | nindent 4 }}
     {{- end }}
+    {{- if .Values.proxy.enabled }}
     - backendRefs:
-        - name: {{ $serviceName }}
-          port: {{ $servicePort }}
+        - name: {{ include "dify.fullname" . }}
+          port: {{ .Values.service.port }}
       {{- with $route.matches }}
       matches:
         {{- toYaml . | nindent 8 }}
@@ -39,4 +38,64 @@ spec:
       filters:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+    {{- else }}
+    {{- if .Values.api.enabled }}
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /console/api
+        - path:
+            type: PathPrefix
+            value: /api
+        - path:
+            type: PathPrefix
+            value: /v1
+        - path:
+            type: PathPrefix
+            value: /files
+        - path:
+            type: PathPrefix
+            value: /openapi
+        - path:
+            type: PathPrefix
+            value: /mcp
+        - path:
+            type: PathPrefix
+            value: /triggers
+      backendRefs:
+        - name: {{ include "dify.api.fullname" . }}
+          port: {{ .Values.api.service.port }}
+    {{- end }}
+    {{- if .Values.pluginDaemon.enabled }}
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /e/
+      backendRefs:
+        - name: {{ include "dify.pluginDaemon.fullname" . }}
+          port: {{ .Values.pluginDaemon.service.ports.daemon }}
+    {{- end }}
+    {{- if .Values.apiWebsocket.enabled }}
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /socket.io
+      backendRefs:
+        - name: {{ include "dify.apiWebsocket.fullname" . }}
+          port: {{ .Values.apiWebsocket.service.port }}
+    {{- end }}
+    {{- if .Values.web.enabled }}
+    - backendRefs:
+        - name: {{ include "dify.web.fullname" . }}
+          port: {{ .Values.web.service.port }}
+      {{- with $route.matches }}
+      matches:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $route.filters }}
+      filters:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- end }}
+    {{- end }}
 {{- end -}}

--- a/charts/dify/values.yaml
+++ b/charts/dify/values.yaml
@@ -1980,8 +1980,7 @@ httproute:
         value: /
   # filters applied to requests that match this rule
   filters: []
-  # additionalRules (templated) prepends custom HTTPRoute rules before the
-  # default single-backend rule above
+  # Extra HTTPRoute rules inserted before the chart’s default rules
   additionalRules: []
 
 # Global node selector


### PR DESCRIPTION
## Summary
- Document Ingress and HTTPRoute access URLs in NOTES (`Access the application at:`)
- Gate proxy Service port-forward notes on `proxy.enabled`
- Omit access notes when Ingress, HTTPRoute, and proxy are all disabled
