### PR TITLE
Warn in `NOTES.txt` when obsolete `pluginDaemon.auth.difyApiKey` is still set

### DIFF
--- a/charts/dify/templates/NOTES.txt
+++ b/charts/dify/templates/NOTES.txt
@@ -1,3 +1,7 @@
+{{- if ((.Values.pluginDaemon).auth).difyApiKey }}
+⚠ WARNING: `pluginDaemon.auth.difyApiKey` is obsolete and no longer takes effect.
+  Set it via `api.auth.internalApiKey` instead.
+{{- end }}
 {{- if .Values.ingress.enabled }}
 1. Access the application at:
   {{- range $host := .Values.ingress.hosts }}


### PR DESCRIPTION
## Summary
Follow-up to #423
- Warn in `NOTES.txt` when `pluginDaemon.auth.difyApiKey` (obsolete) is still set, pointing users to `api.auth.internalApiKey`