### PR TITLE
Make the Helm chart compatible with Dify 1.17.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,22 +45,22 @@ graph TB
     ProxyPod -->|Marketplace| MarketplaceAPI[🛒 Marketplace API<br/>External]
 
     %% Backend Pods
-    APIService --> APIPod[📦 API Pod<br/>langgenius/dify-api:1.16.1<br/>Port: 5001]
-    WebService --> WebPod[📦 Web Pod<br/>langgenius/dify-web:1.16.1<br/>Port: 3000]
-    PluginService --> PluginPod[📦 Plugin Daemon Pod<br/>langgenius/dify-plugin-daemon:0.6.3-local<br/>Ports: 5002, 5003]
+    APIService --> APIPod[📦 API Pod<br/>langgenius/dify-api:1.17.0<br/>Port: 5001]
+    WebService --> WebPod[📦 Web Pod<br/>langgenius/dify-web:1.17.0<br/>Port: 3000]
+    PluginService --> PluginPod[📦 Plugin Daemon Pod<br/>langgenius/dify-plugin-daemon:0.6.10-local<br/>Ports: 5002, 5003]
 
     %% Worker Pod (Background Processing)
-    WorkerPod[📦 Worker Pod<br/>langgenius/dify-api:1.16.1]
+    WorkerPod[📦 Worker Pod<br/>langgenius/dify-api:1.17.0]
 
     %% Beat Pod (Periodic task scheduler)
-    BeatPod[📦 Beat Pod<br/>langgenius/dify-api:1.16.1]
+    BeatPod[📦 Beat Pod<br/>langgenius/dify-api:1.17.0]
 
     %% Sandbox Service
     SandboxService[🏖️ Sandbox Service<br/>Port: 8194] --> SandboxPod[📦 Sandbox Pod<br/>langgenius/dify-sandbox:0.2.15<br/>Port: 8194]
 
     %% Agent Stack
-    AgentBackendService[🤖 Agent Backend Service<br/>Port: 5050] --> AgentBackendPod[📦 Agent Backend Pod<br/>langgenius/dify-agent-backend:1.16.1<br/>Port: 5050]
-    LocalSandboxService[🐚 Local Sandbox Service<br/>Port: 5004] --> LocalSandboxPod[📦 Local Sandbox Pod<br/>langgenius/dify-agent-local-sandbox:1.16.1<br/>Port: 5004]
+    AgentBackendService[🤖 Agent Backend Service<br/>Port: 5050] --> AgentBackendPod[📦 Agent Backend Pod<br/>langgenius/dify-agent-backend:1.17.0<br/>Port: 5050]
+    LocalSandboxService[🐚 Local Sandbox Service<br/>Port: 5004] --> LocalSandboxPod[📦 Local Sandbox Pod<br/>langgenius/dify-agent-local-sandbox:1.17.0<br/>Port: 5004]
 
     %% SSRF Proxy Service
     SSRFService[🛡️ SSRF Proxy Service<br/>Port: 3128] --> SSRFPod[📦 SSRF Proxy Pod<br/>ubuntu/squid:latest<br/>Port: 3128]
@@ -183,15 +183,15 @@ The Nginx proxy handles traffic routing with the following rules:
 
 | Component | Image | Port | Role |
 |-----------|-------|------|------|
-| **API** | `langgenius/dify-api:1.16.1` | 5001 | RESTful API server, business logic processing |
-| **API WebSocket** | `langgenius/dify-api:1.16.1` | 5001 | Socket.IO process for workflow collaboration |
-| **Web** | `langgenius/dify-web:1.16.1` | 3000 | Web UI frontend |
-| **Worker** | `langgenius/dify-api:1.16.1` | - | Background task processing (Celery) |
-| **Beat** | `langgenius/dify-api:1.16.1` | - | Periodic task scheduler (Celery Beat) |
+| **API** | `langgenius/dify-api:1.17.0` | 5001 | RESTful API server, business logic processing |
+| **API WebSocket** | `langgenius/dify-api:1.17.0` | 5001 | Socket.IO process for workflow collaboration |
+| **Web** | `langgenius/dify-web:1.17.0` | 3000 | Web UI frontend |
+| **Worker** | `langgenius/dify-api:1.17.0` | - | Background task processing (Celery) |
+| **Beat** | `langgenius/dify-api:1.17.0` | - | Periodic task scheduler (Celery Beat) |
 | **Sandbox** | `langgenius/dify-sandbox:0.2.15` | 8194 | Secure code execution environment |
-| **Agent Backend** | `langgenius/dify-agent-backend:1.16.1` | 5050 | Agent run orchestration |
-| **Local Sandbox** | `langgenius/dify-agent-local-sandbox:1.16.1` | 5004 | Agent shellctl execution environment |
-| **Plugin Daemon** | `langgenius/dify-plugin-daemon:0.6.3-local` | 5002, 5003 | Plugin management and execution |
+| **Agent Backend** | `langgenius/dify-agent-backend:1.17.0` | 5050 | Agent run orchestration |
+| **Local Sandbox** | `langgenius/dify-agent-local-sandbox:1.17.0` | 5004 | Agent shellctl execution environment |
+| **Plugin Daemon** | `langgenius/dify-plugin-daemon:0.6.10-local` | 5002, 5003 | Plugin management and execution |
 | **SSRF Proxy** | `ubuntu/squid:latest` | 3128 | External request security proxy |
 | **Nginx Proxy** | `nginx:latest` | 80 | Reverse proxy, load balancing |
 

--- a/charts/dify/README.md
+++ b/charts/dify/README.md
@@ -454,7 +454,7 @@ When ExternalSecret is enabled, sensitive information for the following componen
 - **Code Execution Service**: API Key
 - **Plugin System**: Daemon Key, internal API Key
 - **Application Core**: Secret Key
-- **Agent Backend**: API token (shared with API/worker as `AGENT_BACKEND_API_TOKEN` / agent as `DIFY_AGENT_API_TOKEN`), server secret key, shellctl auth token, Redis URL
-- **Local Sandbox**: Shellctl auth token (shared with agent `DIFY_AGENT_SHELLCTL_AUTH_TOKEN`)
+- **Agent Backend**: API token (shared with API/worker as `AGENT_BACKEND_API_TOKEN` / agent as `DIFY_AGENT_API_TOKEN`), server secret key, local sandbox auth token (`DIFY_AGENT_LOCAL_SANDBOX_AUTH_TOKEN`), Redis URL
+- **Local Sandbox**: Shellctl auth token (shared with agent `DIFY_AGENT_LOCAL_SANDBOX_AUTH_TOKEN`)
 
 Usage: Set `externalSecret.enabled: true` in values.yaml and configure the corresponding secretStore and remoteRefs parameters.

--- a/charts/dify/templates/agent-backend-externalsecret.yaml
+++ b/charts/dify/templates/agent-backend-externalsecret.yaml
@@ -1,4 +1,5 @@
 {{- if and .Values.externalSecret.enabled .Values.externalSecret.agentBackend.enabled .Values.agentBackend.enabled }}
+{{- $localSandboxAuth := .Values.externalSecret.agentBackend.remoteRefs.DIFY_AGENT_LOCAL_SANDBOX_AUTH_TOKEN | default .Values.externalSecret.agentBackend.remoteRefs.DIFY_AGENT_SHELLCTL_AUTH_TOKEN }}
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
@@ -27,8 +28,8 @@ spec:
         {{- if .Values.externalSecret.agentBackend.remoteRefs.DIFY_AGENT_SERVER_SECRET_KEY }}
         DIFY_AGENT_SERVER_SECRET_KEY: "{{ `{{ .DIFY_AGENT_SERVER_SECRET_KEY }}` }}"
         {{- end }}
-        {{- if .Values.externalSecret.agentBackend.remoteRefs.DIFY_AGENT_SHELLCTL_AUTH_TOKEN }}
-        DIFY_AGENT_SHELLCTL_AUTH_TOKEN: "{{ `{{ .DIFY_AGENT_SHELLCTL_AUTH_TOKEN }}` }}"
+        {{- if and .Values.localSandbox.enabled $localSandboxAuth }}
+        DIFY_AGENT_LOCAL_SANDBOX_AUTH_TOKEN: "{{ `{{ .DIFY_AGENT_LOCAL_SANDBOX_AUTH_TOKEN }}` }}"
         {{- end }}
         {{- if and .Values.pluginDaemon.enabled .Values.externalSecret.agentBackend.remoteRefs.DIFY_AGENT_PLUGIN_DAEMON_API_KEY }}
         DIFY_AGENT_PLUGIN_DAEMON_API_KEY: "{{ `{{ .DIFY_AGENT_PLUGIN_DAEMON_API_KEY }}` }}"
@@ -97,15 +98,15 @@ spec:
         conversionStrategy: Default
         metadataPolicy: None
     {{- end }}
-    {{- if .Values.externalSecret.agentBackend.remoteRefs.DIFY_AGENT_SHELLCTL_AUTH_TOKEN }}
-    - secretKey: DIFY_AGENT_SHELLCTL_AUTH_TOKEN
+    {{- if and .Values.localSandbox.enabled $localSandboxAuth }}
+    - secretKey: DIFY_AGENT_LOCAL_SANDBOX_AUTH_TOKEN
       remoteRef:
-        key: {{ .Values.externalSecret.agentBackend.remoteRefs.DIFY_AGENT_SHELLCTL_AUTH_TOKEN.key }}
-        {{- if .Values.externalSecret.agentBackend.remoteRefs.DIFY_AGENT_SHELLCTL_AUTH_TOKEN.property }}
-        property: {{ .Values.externalSecret.agentBackend.remoteRefs.DIFY_AGENT_SHELLCTL_AUTH_TOKEN.property }}
+        key: {{ $localSandboxAuth.key }}
+        {{- if $localSandboxAuth.property }}
+        property: {{ $localSandboxAuth.property }}
         {{- end }}
-        {{- if .Values.externalSecret.agentBackend.remoteRefs.DIFY_AGENT_SHELLCTL_AUTH_TOKEN.decodingStrategy }}
-        decodingStrategy: {{ .Values.externalSecret.agentBackend.remoteRefs.DIFY_AGENT_SHELLCTL_AUTH_TOKEN.decodingStrategy }}
+        {{- if $localSandboxAuth.decodingStrategy }}
+        decodingStrategy: {{ $localSandboxAuth.decodingStrategy }}
         {{- else if .Values.externalSecret.decodingStrategy }}
         decodingStrategy: {{ .Values.externalSecret.decodingStrategy }}
         {{- end }}

--- a/charts/dify/templates/config.tpl
+++ b/charts/dify/templates/config.tpl
@@ -23,6 +23,7 @@ FILES_URL: {{ .Values.global.filesDomain | quote }}
 # used to display trigger endpoint API Base URL to the front-end.
 # Example: https://api.dify.ai
 TRIGGER_URL: {{ .Values.global.triggerDomain | quote }}
+DEPLOYMENT_EDITION: {{ .Values.global.edition | quote }}
 {{- end }}
 
 {{- define "dify.api.config" -}}
@@ -177,10 +178,6 @@ CODE_EXECUTION_ENDPOINT: http://{{ template "dify.sandbox.fullname" .}}:{{ .Valu
 {{- end }}
 
 {{- define "dify.web.config" -}}
-{{- if .Values.global.edition }}
-# The edition of the application, SELF_HOSTED or CLOUD
-EDITION: {{ .Values.global.edition | quote }}
-{{- end }}
 # The base URL of console application api server, refers to the Console base URL of WEB service if console domain is
 # different from api or web app domain.
 # example: http://cloud.dify.ai

--- a/charts/dify/templates/config.tpl
+++ b/charts/dify/templates/config.tpl
@@ -549,9 +549,11 @@ DIFY_AGENT_PLUGIN_DAEMON_URL: http://{{ template "dify.pluginDaemon.fullname" .}
 {{- end }}
 DIFY_AGENT_INNER_API_URL: http://{{ template "dify.api.fullname" .}}:{{ .Values.api.service.port }}
 {{- if .Values.localSandbox.enabled }}
-DIFY_AGENT_SHELLCTL_ENTRYPOINT: http://{{ template "dify.localSandbox.fullname" .}}:{{ .Values.localSandbox.service.port }}
+DIFY_AGENT_RUNTIME_BACKEND: "local"
+DIFY_AGENT_LOCAL_SANDBOX_ENDPOINT: http://{{ template "dify.localSandbox.fullname" .}}:{{ .Values.localSandbox.service.port }}
 {{- end }}
 DIFY_AGENT_STUB_API_BASE_URL: http://{{ template "dify.agentBackend.fullname" .}}:{{ .Values.agentBackend.service.port }}/agent-stub
+DIFY_AGENT_SANDBOX_FILES_BASE_URL: http://{{ template "dify.api.fullname" .}}:{{ .Values.api.service.port }}
 {{- end }}
 
 {{- define "dify.localSandbox.config" -}}

--- a/charts/dify/templates/credentials.tpl
+++ b/charts/dify/templates/credentials.tpl
@@ -270,7 +270,9 @@ DIFY_AGENT_REDIS_URL: {{ printf "redis://:%s@%s:%v/2" .auth.password $redisHost 
 DIFY_AGENT_PLUGIN_DAEMON_API_KEY: {{ .Values.pluginDaemon.auth.serverKey | default .Values.global.internalApiKey | b64enc | quote }}
 DIFY_AGENT_INNER_API_KEY: {{ .Values.api.auth.internalApiKey | default .Values.global.internalApiKey | b64enc | quote }}
 {{- end }}
-DIFY_AGENT_SHELLCTL_AUTH_TOKEN: {{ .Values.agentBackend.auth.shellctlAuthToken | b64enc | quote }}
+{{- if .Values.localSandbox.enabled }}
+DIFY_AGENT_LOCAL_SANDBOX_AUTH_TOKEN: {{ .Values.agentBackend.auth.shellctlAuthToken | b64enc | quote }}
+{{- end }}
 DIFY_AGENT_SERVER_SECRET_KEY: {{ .Values.agentBackend.auth.serverSecretKey | b64enc | quote }}
 DIFY_AGENT_API_TOKEN: {{ .Values.agentBackend.auth.apiToken | default .Values.global.internalApiKey | b64enc | quote }}
 {{- end }}

--- a/charts/dify/values.yaml
+++ b/charts/dify/values.yaml
@@ -46,7 +46,7 @@ global:
 image:
   api:
     repository: langgenius/dify-api
-    tag: "1.16.1"
+    tag: "1.17.0"
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -57,7 +57,7 @@ image:
 
   web:
     repository: langgenius/dify-web
-    tag: "1.16.1"
+    tag: "1.17.0"
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -101,7 +101,7 @@ image:
 
   pluginDaemon:
     repository: langgenius/dify-plugin-daemon
-    tag: 0.6.3-local
+    tag: 0.6.10-local
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -112,7 +112,7 @@ image:
 
   agentBackend:
     repository: langgenius/dify-agent-backend
-    tag: "1.16.1"
+    tag: "1.17.0"
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -123,7 +123,7 @@ image:
 
   localSandbox:
     repository: langgenius/dify-agent-local-sandbox
-    tag: "1.16.1"
+    tag: "1.17.0"
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/charts/dify/values.yaml
+++ b/charts/dify/values.yaml
@@ -4,7 +4,7 @@
 
 global:
   # The edition of the application, SELF_HOSTED or CLOUD
-  edition: "SELF_HOSTED"
+  edition: "COMMUNITY"
   # A secret key that is used for securely signing the session cookie and encrypting sensitive information on the database. You can generate a strong key using `openssl rand -base64 42`.
   appSecretKey: "sk-9f73s3ljTXVcMT3Blb3ljTqtsKiGHXVcMT3BlbkFJLK7U"
   # A global secret key for all inter-component API calls among Dify containers (e.g. `api`, `sandbox`, `pluginDaemon` and `agentBackend`). You can generate a strong key using `openssl rand -base64 42`.

--- a/charts/dify/values.yaml
+++ b/charts/dify/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 
 global:
-  # The edition of the application, SELF_HOSTED or CLOUD
+  # The edition of the application
   edition: "COMMUNITY"
   # A secret key that is used for securely signing the session cookie and encrypting sensitive information on the database. You can generate a strong key using `openssl rand -base64 42`.
   appSecretKey: "sk-9f73s3ljTXVcMT3Blb3ljTqtsKiGHXVcMT3BlbkFJLK7U"

--- a/charts/dify/values.yaml
+++ b/charts/dify/values.yaml
@@ -1146,7 +1146,7 @@ agentBackend:
     ## Generate one with: python -c 'import secrets; print(secrets.token_urlsafe(32))'
     ##
     serverSecretKey: "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY"
-    ## @param agentBackend.auth.shellctlAuthToken Shared as agent DIFY_AGENT_SHELLCTL_AUTH_TOKEN and localSandbox SHELLCTL_AUTH_TOKEN
+    ## @param agentBackend.auth.shellctlAuthToken Shared as agent DIFY_AGENT_LOCAL_SANDBOX_AUTH_TOKEN and localSandbox SHELLCTL_AUTH_TOKEN
     ##
     shellctlAuthToken: ""
 
@@ -3550,8 +3550,8 @@ externalSecret:
       DIFY_AGENT_SERVER_SECRET_KEY:
         key: "dify/agent-backend"
         property: "server_secret_key"
-      # Shared with localSandbox SHELLCTL_AUTH_TOKEN
-      DIFY_AGENT_SHELLCTL_AUTH_TOKEN:
+      # Shared with localSandbox SHELLCTL_AUTH_TOKEN. Vault/store property may still be shellctl_auth_token.
+      DIFY_AGENT_LOCAL_SANDBOX_AUTH_TOKEN:
         key: "dify/agent-backend"
         property: "shellctl_auth_token"
       DIFY_AGENT_PLUGIN_DAEMON_API_KEY:
@@ -3569,7 +3569,7 @@ externalSecret:
     # Whether to create ExternalSecret for local sandbox
     enabled: true
     remoteRefs:
-      # Shared with agentBackend DIFY_AGENT_SHELLCTL_AUTH_TOKEN
+      # Shared with agentBackend DIFY_AGENT_LOCAL_SANDBOX_AUTH_TOKEN
       SHELLCTL_AUTH_TOKEN:
         key: "dify/agent-backend"
         property: "shellctl_auth_token"

--- a/ci/values/values-eso-external-s3-pg-es-redis.yaml
+++ b/ci/values/values-eso-external-s3-pg-es-redis.yaml
@@ -1,12 +1,12 @@
 image:
   api:
     repository: langgenius/dify-api
-    tag: "1.16.1"
+    tag: "1.17.0"
     pullPolicy: IfNotPresent
 
   web:
     repository: langgenius/dify-web
-    tag: "1.16.1"
+    tag: "1.17.0"
     pullPolicy: IfNotPresent
 
   sandbox:
@@ -26,17 +26,17 @@ image:
 
   pluginDaemon:
     repository: langgenius/dify-plugin-daemon
-    tag: 0.6.3-local
+    tag: 0.6.10-local
     pullPolicy: IfNotPresent
 
   agentBackend:
     repository: langgenius/dify-agent-backend
-    tag: "1.16.1"
+    tag: "1.17.0"
     pullPolicy: IfNotPresent
 
   localSandbox:
     repository: langgenius/dify-agent-local-sandbox
-    tag: "1.16.1"
+    tag: "1.17.0"
     pullPolicy: IfNotPresent
 
 api:

--- a/ci/values/values-eso-external-s3-pg-es-redis.yaml
+++ b/ci/values/values-eso-external-s3-pg-es-redis.yaml
@@ -480,7 +480,7 @@ externalSecret:
       DIFY_AGENT_SERVER_SECRET_KEY:
         key: "dify/agent-backend"
         property: "server_secret_key"
-      DIFY_AGENT_SHELLCTL_AUTH_TOKEN:
+      DIFY_AGENT_LOCAL_SANDBOX_AUTH_TOKEN:
         key: "dify/agent-backend"
         property: "shellctl_auth_token"
       DIFY_AGENT_PLUGIN_DAEMON_API_KEY:

--- a/ci/values/values-eso-external-s3-pg-es-redis.yaml
+++ b/ci/values/values-eso-external-s3-pg-es-redis.yaml
@@ -172,9 +172,7 @@ web:
     timeoutSeconds: 5
     failureThreshold: 5
     successThreshold: 1
-  extraEnv:
-    - name: EDITION
-      value: "SELF_HOSTED"
+  extraEnv: []
   service:
     port: 3000
     annotations: {}

--- a/ci/values/values-eso-otel.yaml
+++ b/ci/values/values-eso-otel.yaml
@@ -1,12 +1,12 @@
 image:
   api:
     repository: langgenius/dify-api
-    tag: "1.16.1"
+    tag: "1.17.0"
     pullPolicy: IfNotPresent
 
   web:
     repository: langgenius/dify-web
-    tag: "1.16.1"
+    tag: "1.17.0"
     pullPolicy: IfNotPresent
 
   sandbox:
@@ -26,17 +26,17 @@ image:
 
   pluginDaemon:
     repository: langgenius/dify-plugin-daemon
-    tag: 0.6.3-local
+    tag: 0.6.10-local
     pullPolicy: IfNotPresent
 
   agentBackend:
     repository: langgenius/dify-agent-backend
-    tag: "1.16.1"
+    tag: "1.17.0"
     pullPolicy: IfNotPresent
 
   localSandbox:
     repository: langgenius/dify-agent-local-sandbox
-    tag: "1.16.1"
+    tag: "1.17.0"
     pullPolicy: IfNotPresent
 
 api:

--- a/ci/values/values-eso-otel.yaml
+++ b/ci/values/values-eso-otel.yaml
@@ -2533,7 +2533,7 @@ externalSecret:
       DIFY_AGENT_SERVER_SECRET_KEY:
         key: "dify/agent-backend"
         property: "server_secret_key"
-      DIFY_AGENT_SHELLCTL_AUTH_TOKEN:
+      DIFY_AGENT_LOCAL_SANDBOX_AUTH_TOKEN:
         key: "dify/agent-backend"
         property: "shellctl_auth_token"
       DIFY_AGENT_PLUGIN_DAEMON_API_KEY:

--- a/ci/values/values-eso-otel.yaml
+++ b/ci/values/values-eso-otel.yaml
@@ -471,8 +471,6 @@ web:
   containerSecurityContext: {}
   extraEnv:
     # Apply your own Environment Variables if necessary
-    - name: EDITION
-      value: "SELF_HOSTED"
   service:
     port: 3000
     annotations: {}

--- a/ci/values/values-eso.yaml
+++ b/ci/values/values-eso.yaml
@@ -1,12 +1,12 @@
 image:
   api:
     repository: langgenius/dify-api
-    tag: "1.16.1"
+    tag: "1.17.0"
     pullPolicy: IfNotPresent
 
   web:
     repository: langgenius/dify-web
-    tag: "1.16.1"
+    tag: "1.17.0"
     pullPolicy: IfNotPresent
 
   sandbox:
@@ -26,17 +26,17 @@ image:
 
   pluginDaemon:
     repository: langgenius/dify-plugin-daemon
-    tag: 0.6.3-local
+    tag: 0.6.10-local
     pullPolicy: IfNotPresent
 
   agentBackend:
     repository: langgenius/dify-agent-backend
-    tag: "1.16.1"
+    tag: "1.17.0"
     pullPolicy: IfNotPresent
 
   localSandbox:
     repository: langgenius/dify-agent-local-sandbox
-    tag: "1.16.1"
+    tag: "1.17.0"
     pullPolicy: IfNotPresent
 
 api:

--- a/ci/values/values-eso.yaml
+++ b/ci/values/values-eso.yaml
@@ -2752,7 +2752,7 @@ externalSecret:
       DIFY_AGENT_SERVER_SECRET_KEY:
         key: "dify/agent-backend"
         property: "server_secret_key"
-      DIFY_AGENT_SHELLCTL_AUTH_TOKEN:
+      DIFY_AGENT_LOCAL_SANDBOX_AUTH_TOKEN:
         key: "dify/agent-backend"
         property: "shellctl_auth_token"
       DIFY_AGENT_PLUGIN_DAEMON_API_KEY:

--- a/ci/values/values-eso.yaml
+++ b/ci/values/values-eso.yaml
@@ -467,8 +467,6 @@ web:
   containerSecurityContext: {}
   extraEnv:
     # Apply your own Environment Variables if necessary
-    - name: EDITION
-      value: "SELF_HOSTED"
   service:
     port: 3000
     annotations: {}

--- a/ci/values/values-legacy-external-all.yaml
+++ b/ci/values/values-legacy-external-all.yaml
@@ -1,12 +1,12 @@
 image:
   api:
     repository: langgenius/dify-api
-    tag: "1.16.1"
+    tag: "1.17.0"
     pullPolicy: IfNotPresent
 
   web:
     repository: langgenius/dify-web
-    tag: "1.16.1"
+    tag: "1.17.0"
     pullPolicy: IfNotPresent
 
   sandbox:
@@ -26,17 +26,17 @@ image:
 
   pluginDaemon:
     repository: langgenius/dify-plugin-daemon
-    tag: 0.6.3-local
+    tag: 0.6.10-local
     pullPolicy: IfNotPresent
 
   agentBackend:
     repository: langgenius/dify-agent-backend
-    tag: "1.16.1"
+    tag: "1.17.0"
     pullPolicy: IfNotPresent
 
   localSandbox:
     repository: langgenius/dify-agent-local-sandbox
-    tag: "1.16.1"
+    tag: "1.17.0"
     pullPolicy: IfNotPresent
 
 api:

--- a/ci/values/values-legacy-external-all.yaml
+++ b/ci/values/values-legacy-external-all.yaml
@@ -389,8 +389,6 @@ web:
   containerSecurityContext: {}
   extraEnv:
     # Apply your own Environment Variables if necessary
-    - name: EDITION
-      value: "SELF_HOSTED"
   service:
     port: 3000
     annotations: {}

--- a/ci/values/values-legacy-external-mysql-all.yaml
+++ b/ci/values/values-legacy-external-mysql-all.yaml
@@ -1,12 +1,12 @@
 image:
   api:
     repository: langgenius/dify-api
-    tag: "1.16.1"
+    tag: "1.17.0"
     pullPolicy: IfNotPresent
 
   web:
     repository: langgenius/dify-web
-    tag: "1.16.1"
+    tag: "1.17.0"
     pullPolicy: IfNotPresent
 
   sandbox:
@@ -26,17 +26,17 @@ image:
 
   pluginDaemon:
     repository: langgenius/dify-plugin-daemon
-    tag: 0.6.3-local
+    tag: 0.6.10-local
     pullPolicy: IfNotPresent
 
   agentBackend:
     repository: langgenius/dify-agent-backend
-    tag: "1.16.1"
+    tag: "1.17.0"
     pullPolicy: IfNotPresent
 
   localSandbox:
     repository: langgenius/dify-agent-local-sandbox
-    tag: "1.16.1"
+    tag: "1.17.0"
     pullPolicy: IfNotPresent
 
 api:

--- a/ci/values/values-legacy-external-mysql-all.yaml
+++ b/ci/values/values-legacy-external-mysql-all.yaml
@@ -389,8 +389,6 @@ web:
   containerSecurityContext: {}
   extraEnv:
     # Apply your own Environment Variables if necessary
-    - name: EDITION
-      value: "SELF_HOSTED"
   service:
     port: 3000
     annotations: {}

--- a/ci/values/values-legacy.yaml
+++ b/ci/values/values-legacy.yaml
@@ -5,12 +5,12 @@
 image:
   api:
     repository: langgenius/dify-api
-    tag: "1.16.1"
+    tag: "1.17.0"
     pullPolicy: IfNotPresent
 
   web:
     repository: langgenius/dify-web
-    tag: "1.16.1"
+    tag: "1.17.0"
     pullPolicy: IfNotPresent
 
   sandbox:
@@ -30,17 +30,17 @@ image:
 
   pluginDaemon:
     repository: langgenius/dify-plugin-daemon
-    tag: 0.6.3-local
+    tag: 0.6.10-local
     pullPolicy: IfNotPresent
 
   agentBackend:
     repository: langgenius/dify-agent-backend
-    tag: "1.16.1"
+    tag: "1.17.0"
     pullPolicy: IfNotPresent
 
   localSandbox:
     repository: langgenius/dify-agent-local-sandbox
-    tag: "1.16.1"
+    tag: "1.17.0"
     pullPolicy: IfNotPresent
 
 api:

--- a/ci/values/values-legacy.yaml
+++ b/ci/values/values-legacy.yaml
@@ -471,8 +471,6 @@ web:
   containerSecurityContext: {}
   extraEnv:
     # Apply your own Environment Variables if necessary
-    - name: EDITION
-      value: "SELF_HOSTED"
   service:
     port: 3000
     annotations: {}


### PR DESCRIPTION
## Summary
- Bump image tags for Dify 1.17.0.
- Update environment variable to match requirement of local-sandbox and agent-backend in Dify 1.17.0
- Change default `global.edition` to `COMMUNITY` and emit `DEPLOYMENT_EDITION` instead of `EDITION`.

## Breaking changes
For users who copied or overlaid `values.yaml` from a previous versions, make sure to update the following keys:

- `global.edition`: default is now `COMMUNITY` as `SELF_HOSTED` is no longer valid.
- External Secret Operator: rename `externalSecret.agentBackend.remoteRefs.DIFY_AGENT_SHELLCTL_AUTH_TOKEN` to `DIFY_AGENT_LOCAL_SANDBOX_AUTH_TOKEN`.