### PR TITLE
Add local-sandbox persistence for agent homes, workspaces, and snapshots

### DIFF
--- a/charts/dify/templates/config.tpl
+++ b/charts/dify/templates/config.tpl
@@ -551,6 +551,13 @@ DIFY_AGENT_INNER_API_URL: http://{{ template "dify.api.fullname" .}}:{{ .Values.
 {{- if .Values.localSandbox.enabled }}
 DIFY_AGENT_RUNTIME_BACKEND: "local"
 DIFY_AGENT_LOCAL_SANDBOX_ENDPOINT: http://{{ template "dify.localSandbox.fullname" .}}:{{ .Values.localSandbox.service.port }}
+{{- if .Values.localSandbox.persistence.home.enabled }}
+DIFY_AGENT_LOCAL_SANDBOX_MATERIALIZED_HOME_ROOT: {{ .Values.localSandbox.persistence.home.mountPath | quote }}
+DIFY_AGENT_LOCAL_SANDBOX_HOME_SNAPSHOT_ROOT: {{ printf "%s/.snapshots" .Values.localSandbox.persistence.home.mountPath | quote }}
+{{- end }}
+{{- if .Values.localSandbox.persistence.workspace.enabled }}
+DIFY_AGENT_LOCAL_SANDBOX_WORKSPACE_ROOT: {{ .Values.localSandbox.persistence.workspace.mountPath | quote }}
+{{- end }}
 {{- end }}
 DIFY_AGENT_STUB_API_BASE_URL: http://{{ template "dify.agentBackend.fullname" .}}:{{ .Values.agentBackend.service.port }}/agent-stub
 DIFY_AGENT_SANDBOX_FILES_BASE_URL: http://{{ template "dify.api.fullname" .}}:{{ .Values.api.service.port }}

--- a/charts/dify/templates/local-sandbox-deployment.yaml
+++ b/charts/dify/templates/local-sandbox-deployment.yaml
@@ -1,4 +1,6 @@
 {{- if .Values.localSandbox.enabled }}
+{{- $useHomePvc := .Values.localSandbox.persistence.home.enabled }}
+{{- $useWorkspacePvc := .Values.localSandbox.persistence.workspace.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -108,14 +110,20 @@ spec:
               protocol: TCP
           resources:
             {{- toYaml .Values.localSandbox.resources | nindent 14 }}
-          {{- if .Values.localSandbox.extraVolumeMounts }}
           volumeMounts:
+            {{- if $useHomePvc }}
+            - name: home-data
+              mountPath: {{ .Values.localSandbox.persistence.home.mountPath | quote }}
+              subPath: {{ .Values.localSandbox.persistence.home.persistentVolumeClaim.subPath | default "" }}
+            {{- end }}
+            {{- if $useWorkspacePvc }}
+            - name: workspace-data
+              mountPath: {{ .Values.localSandbox.persistence.workspace.mountPath | quote }}
+              subPath: {{ .Values.localSandbox.persistence.workspace.persistentVolumeClaim.subPath | default "" }}
+            {{- end }}
+            {{- if .Values.localSandbox.extraVolumeMounts }}
             {{- include "common.tplvalues.render" (dict "value" .Values.localSandbox.extraVolumeMounts "context" $) | nindent 12 }}
-          {{- end }}
-      {{- if .Values.localSandbox.extraVolumes }}
-      volumes:
-        {{- include "common.tplvalues.render" (dict "value" .Values.localSandbox.extraVolumes "context" $) | nindent 8 }}
-      {{- end }}
+            {{- end }}
     {{- if and (.Values.nodeSelector) (not .Values.localSandbox.nodeSelector) }}
       nodeSelector:
         {{- toYaml .Values.nodeSelector | nindent 8 }}
@@ -140,4 +148,18 @@ spec:
       tolerations:
         {{- toYaml .Values.localSandbox.tolerations | nindent 8 }}
     {{- end }}
+      volumes:
+        {{- if $useHomePvc }}
+        - name: home-data
+          persistentVolumeClaim:
+            claimName: {{ .Values.localSandbox.persistence.home.persistentVolumeClaim.existingClaim | default (printf "%s-home" (include "dify.localSandbox.fullname" . | trunc 58)) }}
+        {{- end }}
+        {{- if $useWorkspacePvc }}
+        - name: workspace-data
+          persistentVolumeClaim:
+            claimName: {{ .Values.localSandbox.persistence.workspace.persistentVolumeClaim.existingClaim | default (printf "%s-workspace" (include "dify.localSandbox.fullname" . | trunc 53)) }}
+        {{- end }}
+        {{- if .Values.localSandbox.extraVolumes }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.localSandbox.extraVolumes "context" $) | nindent 8 }}
+        {{- end }}
 {{- end }}

--- a/charts/dify/templates/pvc.yaml
+++ b/charts/dify/templates/pvc.yaml
@@ -137,3 +137,63 @@ spec:
       storage: {{ $pvc.size }}
 {{- end }}
 {{- end }}
+
+
+{{- if .Values.localSandbox.enabled }}
+{{- $homePvc := .Values.localSandbox.persistence.home.persistentVolumeClaim -}}
+{{- if and .Values.localSandbox.persistence.home.enabled (not $homePvc.existingClaim) }}
+---
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ printf "%s-home" (include "dify.localSandbox.fullname" . | trunc 58) }}
+{{- with .Values.localSandbox.persistence.home.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+{{- end }}
+  labels:
+    {{- include "dify.labels" . | nindent 4 }}
+spec:
+  accessModes:
+  - {{ $homePvc.accessModes | quote }}
+  {{- if $homePvc.storageClass }}
+  {{- if eq "-" $homePvc.storageClass }}
+  storageClassName: ""
+  {{- else }}
+  storageClassName: {{ $homePvc.storageClass }}
+  {{- end }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ $homePvc.size }}
+{{- end }}
+{{- $workspacePvc := .Values.localSandbox.persistence.workspace.persistentVolumeClaim -}}
+{{- if and .Values.localSandbox.persistence.workspace.enabled (not $workspacePvc.existingClaim) }}
+---
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ printf "%s-workspace" (include "dify.localSandbox.fullname" . | trunc 53) }}
+{{- with .Values.localSandbox.persistence.workspace.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+{{- end }}
+  labels:
+    {{- include "dify.labels" . | nindent 4 }}
+spec:
+  accessModes:
+  - {{ $workspacePvc.accessModes | quote }}
+  {{- if $workspacePvc.storageClass }}
+  {{- if eq "-" $workspacePvc.storageClass }}
+  storageClassName: ""
+  {{- else }}
+  storageClassName: {{ $workspacePvc.storageClass }}
+  {{- end }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ $workspacePvc.size }}
+{{- end }}
+{{- end }}

--- a/charts/dify/values.schema.json
+++ b/charts/dify/values.schema.json
@@ -1061,6 +1061,47 @@
         "podSecurityContext": { "type": "object" },
         "containerSecurityContext": { "type": "object" },
         "extraEnv": { "type": "array" },
+        "persistence": {
+          "type": "object",
+          "properties": {
+            "home": {
+              "type": "object",
+              "properties": {
+                "enabled": { "type": "boolean" },
+                "mountPath": { "type": "string" },
+                "annotations": { "type": "object" },
+                "persistentVolumeClaim": {
+                  "type": "object",
+                  "properties": {
+                    "existingClaim": { "type": "string" },
+                    "storageClass": { "type": ["string", "null"] },
+                    "accessModes": { "type": "string" },
+                    "size": { "type": "string" },
+                    "subPath": { "type": "string" }
+                  }
+                }
+              }
+            },
+            "workspace": {
+              "type": "object",
+              "properties": {
+                "enabled": { "type": "boolean" },
+                "mountPath": { "type": "string" },
+                "annotations": { "type": "object" },
+                "persistentVolumeClaim": {
+                  "type": "object",
+                  "properties": {
+                    "existingClaim": { "type": "string" },
+                    "storageClass": { "type": ["string", "null"] },
+                    "accessModes": { "type": "string" },
+                    "size": { "type": "string" },
+                    "subPath": { "type": "string" }
+                  }
+                }
+              }
+            }
+          }
+        },
         "extraVolumes": { "type": "array" },
         "extraVolumeMounts": { "type": "array" },
         "service": {

--- a/charts/dify/values.yaml
+++ b/charts/dify/values.yaml
@@ -1223,6 +1223,43 @@ localSandbox:
   # Configure Container Security Context
   containerSecurityContext: {}
   extraEnv: []
+  persistence:
+    home:
+      ## @param localSandbox.persistence.home.enabled Enable persistence on home using Persistent Volume Claims
+      ##
+      enabled: true
+      mountPath: "/home/dify"
+      annotations:
+        helm.sh/resource-policy: keep
+      persistentVolumeClaim:
+        existingClaim: ""
+        ## Local sandbox home Persistent Volume Storage Class
+        ## If defined, storageClassName: <storageClass>
+        ## If set to "-", storageClassName: "", which disables dynamic provisioning
+        ## If undefined (the default) or set to null, no storageClassName spec is
+        ##   set, choosing the default provisioner.
+        storageClass:
+        accessModes: ReadWriteOnce
+        size: 5Gi
+        subPath: ""
+    workspace:
+      ## @param localSandbox.persistence.workspace.enabled Enable persistence on agent workspace using Persistent Volume Claims
+      ##
+      enabled: true
+      mountPath: "/workspace"
+      annotations:
+        helm.sh/resource-policy: keep
+      persistentVolumeClaim:
+        existingClaim: ""
+        ## Local sandbox workspace Persistent Volume Storage Class
+        ## If defined, storageClassName: <storageClass>
+        ## If set to "-", storageClassName: "", which disables dynamic provisioning
+        ## If undefined (the default) or set to null, no storageClassName spec is
+        ##   set, choosing the default provisioner.
+        storageClass:
+        accessModes: ReadWriteOnce
+        size: 5Gi
+        subPath: ""
   ## @param localSandbox.extraVolumes Optionally specify extra list of additional volumes for the local sandbox pod(s)
   ##
   extraVolumes: []


### PR DESCRIPTION
## Summary
- Persist local sandbox agent homes (`/home/dify`) and workspaces (`/workspace`) on separate PVCs (default on, `existingClaim` supported).
- Snapshots stay on the home volume at `<home.mountPath>/.snapshots`.
- When those volumes are enabled, agent_backend gets matching `DIFY_AGENT_LOCAL_SANDBOX_*` path env so it uses the same roots.