### PR TITLE
Run local sandbox as uid 1000 by default

### DIFF
--- a/charts/dify/templates/local-sandbox-deployment.yaml
+++ b/charts/dify/templates/local-sandbox-deployment.yaml
@@ -60,9 +60,8 @@ spec:
       hostAliases:
         {{- toYaml .Values.localSandbox.hostAliases | nindent 8 }}
       {{- end }}
-      {{- if .Values.localSandbox.podSecurityContext }}
-      securityContext:
-        {{- toYaml .Values.localSandbox.podSecurityContext | nindent 8 }}
+      {{- if .Values.localSandbox.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.localSandbox.podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}
       containers:
         - image: "{{ .Values.image.localSandbox.repository }}:{{ default .Chart.AppVersion .Values.image.localSandbox.tag }}"
@@ -91,9 +90,8 @@ spec:
             tcpSocket:
               port: local-sandbox
           {{- end }}
-          {{- if .Values.localSandbox.containerSecurityContext }}
-          securityContext:
-            {{- toYaml .Values.localSandbox.containerSecurityContext | nindent 12 }}
+          {{- if .Values.localSandbox.containerSecurityContext.enabled }}
+          securityContext: {{- omit .Values.localSandbox.containerSecurityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}
           env:
             {{- if .Values.localSandbox.extraEnv }}

--- a/charts/dify/values.yaml
+++ b/charts/dify/values.yaml
@@ -1218,10 +1218,28 @@ localSandbox:
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##
   hostAliases: []
-  # Configure Pods Security Context
-  podSecurityContext: {}
-  # Configure Container Security Context
-  containerSecurityContext: {}
+  ## Configure Pods Security Context
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+  ## @param localSandbox.podSecurityContext.enabled Enabled Dify local sandbox pod's Security Context
+  ## @param localSandbox.podSecurityContext.fsGroup Set Dify local sandbox pod's Security Context fsGroup
+  ## @param localSandbox.podSecurityContext.fsGroupChangePolicy Set Dify local sandbox pod's Security Context fsGroupChangePolicy
+  ##
+  podSecurityContext:
+    enabled: true
+    fsGroup: 1000
+    fsGroupChangePolicy: OnRootMismatch
+  ## Configure Container Security Context
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+  ## @param localSandbox.containerSecurityContext.enabled Dify local sandbox containers' Security Context
+  ## @param localSandbox.containerSecurityContext.runAsUser Set Dify local sandbox containers' Security Context runAsUser
+  ## @param localSandbox.containerSecurityContext.runAsGroup Set Dify local sandbox containers' Security Context runAsGroup
+  ## @param localSandbox.containerSecurityContext.runAsNonRoot Set Dify local sandbox containers' Security Context runAsNonRoot
+  ##
+  containerSecurityContext:
+    enabled: true
+    runAsUser: 1000
+    runAsGroup: 1000
+    runAsNonRoot: true
   extraEnv: []
   persistence:
     home:


### PR DESCRIPTION
## Summary
- Default local-sandbox `podSecurityContext` / `containerSecurityContext` to non-root uid/gid `1000`, matching the sandbox image user.
- Set `fsGroup: 1000` and `fsGroupChangePolicy: OnRootMismatch` so new PVCs are writable without recowning volumes that already match.