### PR TITLE
Add external E2B sandbox runtime for Agent Backend

### DIFF
--- a/charts/dify/README.md
+++ b/charts/dify/README.md
@@ -19,7 +19,7 @@ Fear not its extensive content as it is arranged in sections below:
 1. Image: Adjust images of all Dify components
 2. Dify Service: Customize configurations of each Dify component
 3. Middleware: Specifies the configuration of built-in middlewares
-4. External services: Substitute external services for built-in data persistence
+4. External services: Substitute external services for built-in middlewares, data persistence and agent sandboxes
  
 ### 1. Use Alternative Images
 You can specify custom images for different components:

--- a/charts/dify/README.md
+++ b/charts/dify/README.md
@@ -140,6 +140,22 @@ externalRedis:
 ```
 Refer to `external<Service>` sections in `values.yaml` for each component to be used.
 
+#### External E2B sandbox (Agent runtime)
+
+Default install keeps Agent runtime `local` with in-cluster `localSandbox` and does not set `DIFY_AGENT_E2B_*`. Workflow Code-node `sandbox` / `CODE_EXECUTION_*` is unrelated.
+
+To use E2B Cloud instead, set `externalE2bSandbox.enabled: true`. Agent Backend stays running; the chart sets `DIFY_AGENT_RUNTIME_BACKEND=e2b` and `DIFY_AGENT_E2B_API_KEY` (not `E2B_API_KEY` / `E2B_API_TOKEN`) and omits `DIFY_AGENT_LOCAL_SANDBOX_*` even if `localSandbox.enabled` is still true. Recommend `localSandbox.enabled: false` so the unused sandbox is not deployed. Agent Backend needs egress to E2B. With ExternalSecret, provide `DIFY_AGENT_E2B_API_KEY` under `externalSecret.agentBackend.remoteRefs`.
+
+```yaml
+# values.yaml
+localSandbox:
+  enabled: false
+
+externalE2bSandbox:
+  enabled: true
+  apiKey: "your-e2b-api-key"
+```
+
 ## Advanced Topics
 ### Migrate Built-in Redis and PostgreSQL instances as Separate Releases
 #### Intro
@@ -454,7 +470,7 @@ When ExternalSecret is enabled, sensitive information for the following componen
 - **Code Execution Service**: API Key
 - **Plugin System**: Daemon Key, internal API Key
 - **Application Core**: Secret Key
-- **Agent Backend**: API token (shared with API/worker as `AGENT_BACKEND_API_TOKEN` / agent as `DIFY_AGENT_API_TOKEN`), server secret key, local sandbox auth token (`DIFY_AGENT_LOCAL_SANDBOX_AUTH_TOKEN`), Redis URL
+- **Agent Backend**: API token (shared with API/worker as `AGENT_BACKEND_API_TOKEN` / agent as `DIFY_AGENT_API_TOKEN`), server secret key, local sandbox auth token (`DIFY_AGENT_LOCAL_SANDBOX_AUTH_TOKEN`), E2B API key (`DIFY_AGENT_E2B_API_KEY` when `externalE2bSandbox.enabled`), Redis URL
 - **Local Sandbox**: Shellctl auth token (shared with agent `DIFY_AGENT_LOCAL_SANDBOX_AUTH_TOKEN`)
 
 Usage: Set `externalSecret.enabled: true` in values.yaml and configure the corresponding secretStore and remoteRefs parameters.

--- a/charts/dify/templates/agent-backend-deployment.yaml
+++ b/charts/dify/templates/agent-backend-deployment.yaml
@@ -30,6 +30,9 @@ spec:
       annotations:
         checksum/agent-backend-config: {{ include (print $.Template.BasePath "/agent-backend-config.yaml") . | sha256sum }}
         checksum/agent-backend-secret: {{ include (print $.Template.BasePath "/agent-backend-secret.yaml") . | sha256sum }}
+        {{- if and .Values.externalE2bSandbox.enabled .Values.externalE2bSandbox.tls.enabled (not .Values.externalE2bSandbox.tls.existingSecret) }}
+        checksum/e2b-tls-secret: {{ include (print $.Template.BasePath "/e2b-tls-secret.yaml") . | sha256sum }}
+        {{- end }}
         {{- include "dify.ud.annotations" . | nindent 8 }}
       labels:
         {{- include "dify.selectorLabels" . | nindent 8 }}
@@ -106,13 +109,30 @@ spec:
               protocol: TCP
           resources:
             {{- toYaml .Values.agentBackend.resources | nindent 14 }}
-          {{- if .Values.agentBackend.extraVolumeMounts }}
+          {{- if or (and .Values.externalE2bSandbox.enabled .Values.externalE2bSandbox.tls.enabled) .Values.agentBackend.extraVolumeMounts }}
           volumeMounts:
+            {{- if and .Values.externalE2bSandbox.enabled .Values.externalE2bSandbox.tls.enabled }}
+            - name: e2b-tls-ca
+              mountPath: /etc/ssl/dify/e2b
+              readOnly: true
+            {{- end }}
+            {{- if .Values.agentBackend.extraVolumeMounts }}
             {{- include "common.tplvalues.render" (dict "value" .Values.agentBackend.extraVolumeMounts "context" $) | nindent 12 }}
+            {{- end }}
           {{- end }}
-      {{- if .Values.agentBackend.extraVolumes }}
+      {{- if or (and .Values.externalE2bSandbox.enabled .Values.externalE2bSandbox.tls.enabled) .Values.agentBackend.extraVolumes }}
       volumes:
+        {{- if and .Values.externalE2bSandbox.enabled .Values.externalE2bSandbox.tls.enabled }}
+        - name: e2b-tls-ca
+          secret:
+            secretName: {{ default (printf "%s-e2b-tls" (include "dify.fullname" .)) .Values.externalE2bSandbox.tls.existingSecret }}
+            items:
+              - key: {{ .Values.externalE2bSandbox.tls.certCAFilename | quote }}
+                path: {{ .Values.externalE2bSandbox.tls.certCAFilename | quote }}
+        {{- end }}
+        {{- if .Values.agentBackend.extraVolumes }}
         {{- include "common.tplvalues.render" (dict "value" .Values.agentBackend.extraVolumes "context" $) | nindent 8 }}
+        {{- end }}
       {{- end }}
     {{- if and (.Values.nodeSelector) (not .Values.agentBackend.nodeSelector) }}
       nodeSelector:

--- a/charts/dify/templates/agent-backend-externalsecret.yaml
+++ b/charts/dify/templates/agent-backend-externalsecret.yaml
@@ -27,8 +27,11 @@ spec:
         {{- if .Values.externalSecret.agentBackend.remoteRefs.DIFY_AGENT_SERVER_SECRET_KEY }}
         DIFY_AGENT_SERVER_SECRET_KEY: "{{ `{{ .DIFY_AGENT_SERVER_SECRET_KEY }}` }}"
         {{- end }}
-        {{- if and .Values.localSandbox.enabled .Values.externalSecret.agentBackend.remoteRefs.DIFY_AGENT_LOCAL_SANDBOX_AUTH_TOKEN }}
+        {{- if and (not .Values.externalE2bSandbox.enabled) .Values.localSandbox.enabled .Values.externalSecret.agentBackend.remoteRefs.DIFY_AGENT_LOCAL_SANDBOX_AUTH_TOKEN }}
         DIFY_AGENT_LOCAL_SANDBOX_AUTH_TOKEN: "{{ `{{ .DIFY_AGENT_LOCAL_SANDBOX_AUTH_TOKEN }}` }}"
+        {{- end }}
+        {{- if and .Values.externalE2bSandbox.enabled .Values.externalSecret.agentBackend.remoteRefs.DIFY_AGENT_E2B_API_KEY }}
+        DIFY_AGENT_E2B_API_KEY: "{{ `{{ .DIFY_AGENT_E2B_API_KEY }}` }}"
         {{- end }}
         {{- if and .Values.pluginDaemon.enabled .Values.externalSecret.agentBackend.remoteRefs.DIFY_AGENT_PLUGIN_DAEMON_API_KEY }}
         DIFY_AGENT_PLUGIN_DAEMON_API_KEY: "{{ `{{ .DIFY_AGENT_PLUGIN_DAEMON_API_KEY }}` }}"
@@ -97,7 +100,7 @@ spec:
         conversionStrategy: Default
         metadataPolicy: None
     {{- end }}
-    {{- if and .Values.localSandbox.enabled .Values.externalSecret.agentBackend.remoteRefs.DIFY_AGENT_LOCAL_SANDBOX_AUTH_TOKEN }}
+    {{- if and (not .Values.externalE2bSandbox.enabled) .Values.localSandbox.enabled .Values.externalSecret.agentBackend.remoteRefs.DIFY_AGENT_LOCAL_SANDBOX_AUTH_TOKEN }}
     - secretKey: DIFY_AGENT_LOCAL_SANDBOX_AUTH_TOKEN
       remoteRef:
         key: {{ .Values.externalSecret.agentBackend.remoteRefs.DIFY_AGENT_LOCAL_SANDBOX_AUTH_TOKEN.key }}
@@ -106,6 +109,21 @@ spec:
         {{- end }}
         {{- if .Values.externalSecret.agentBackend.remoteRefs.DIFY_AGENT_LOCAL_SANDBOX_AUTH_TOKEN.decodingStrategy }}
         decodingStrategy: {{ .Values.externalSecret.agentBackend.remoteRefs.DIFY_AGENT_LOCAL_SANDBOX_AUTH_TOKEN.decodingStrategy }}
+        {{- else if .Values.externalSecret.decodingStrategy }}
+        decodingStrategy: {{ .Values.externalSecret.decodingStrategy }}
+        {{- end }}
+        conversionStrategy: Default
+        metadataPolicy: None
+    {{- end }}
+    {{- if and .Values.externalE2bSandbox.enabled .Values.externalSecret.agentBackend.remoteRefs.DIFY_AGENT_E2B_API_KEY }}
+    - secretKey: DIFY_AGENT_E2B_API_KEY
+      remoteRef:
+        key: {{ .Values.externalSecret.agentBackend.remoteRefs.DIFY_AGENT_E2B_API_KEY.key }}
+        {{- if .Values.externalSecret.agentBackend.remoteRefs.DIFY_AGENT_E2B_API_KEY.property }}
+        property: {{ .Values.externalSecret.agentBackend.remoteRefs.DIFY_AGENT_E2B_API_KEY.property }}
+        {{- end }}
+        {{- if .Values.externalSecret.agentBackend.remoteRefs.DIFY_AGENT_E2B_API_KEY.decodingStrategy }}
+        decodingStrategy: {{ .Values.externalSecret.agentBackend.remoteRefs.DIFY_AGENT_E2B_API_KEY.decodingStrategy }}
         {{- else if .Values.externalSecret.decodingStrategy }}
         decodingStrategy: {{ .Values.externalSecret.decodingStrategy }}
         {{- end }}

--- a/charts/dify/templates/config.tpl
+++ b/charts/dify/templates/config.tpl
@@ -550,6 +550,18 @@ DIFY_AGENT_PLUGIN_DAEMON_URL: http://{{ template "dify.pluginDaemon.fullname" .}
 DIFY_AGENT_INNER_API_URL: http://{{ template "dify.api.fullname" .}}:{{ .Values.api.service.port }}
 {{- if .Values.externalE2bSandbox.enabled }}
 DIFY_AGENT_RUNTIME_BACKEND: "e2b"
+{{- if .Values.externalE2bSandbox.apiUrl }}
+E2B_API_URL: {{ .Values.externalE2bSandbox.apiUrl | quote }}
+{{- end }}
+{{- if .Values.externalE2bSandbox.domain }}
+E2B_DOMAIN: {{ .Values.externalE2bSandbox.domain | quote }}
+{{- end }}
+{{- if .Values.externalE2bSandbox.template }}
+DIFY_AGENT_E2B_TEMPLATE: {{ .Values.externalE2bSandbox.template | quote }}
+{{- end }}
+{{- if .Values.externalE2bSandbox.tls.enabled }}
+SSL_CERT_FILE: {{ printf "/etc/ssl/dify/e2b/%s" .Values.externalE2bSandbox.tls.certCAFilename | quote }}
+{{- end }}
 {{- else if .Values.localSandbox.enabled }}
 DIFY_AGENT_RUNTIME_BACKEND: "local"
 DIFY_AGENT_LOCAL_SANDBOX_ENDPOINT: http://{{ template "dify.localSandbox.fullname" .}}:{{ .Values.localSandbox.service.port }}

--- a/charts/dify/templates/config.tpl
+++ b/charts/dify/templates/config.tpl
@@ -548,7 +548,9 @@ HTTPS_PROXY: http://{{ template "dify.ssrfProxy.fullname" .}}:{{ .Values.ssrfPro
 DIFY_AGENT_PLUGIN_DAEMON_URL: http://{{ template "dify.pluginDaemon.fullname" .}}:{{ .Values.pluginDaemon.service.ports.daemon }}
 {{- end }}
 DIFY_AGENT_INNER_API_URL: http://{{ template "dify.api.fullname" .}}:{{ .Values.api.service.port }}
-{{- if .Values.localSandbox.enabled }}
+{{- if .Values.externalE2bSandbox.enabled }}
+DIFY_AGENT_RUNTIME_BACKEND: "e2b"
+{{- else if .Values.localSandbox.enabled }}
 DIFY_AGENT_RUNTIME_BACKEND: "local"
 DIFY_AGENT_LOCAL_SANDBOX_ENDPOINT: http://{{ template "dify.localSandbox.fullname" .}}:{{ .Values.localSandbox.service.port }}
 {{- if .Values.localSandbox.persistence.home.enabled }}

--- a/charts/dify/templates/config.tpl
+++ b/charts/dify/templates/config.tpl
@@ -708,6 +708,13 @@ server {
     }
     {{- end }}
 
+    {{- if and .Values.externalE2bSandbox.enabled .Values.agentBackend.enabled }}
+    location /agent-stub {
+      proxy_pass http://{{ template "dify.agentBackend.fullname" .}}:{{ .Values.agentBackend.service.port }};
+      include proxy.conf;
+    }
+    {{- end }}
+
     location / {
       proxy_pass http://{{ template "dify.web.fullname" .}}:{{ .Values.web.service.port }};
       include proxy.conf;

--- a/charts/dify/templates/credentials.tpl
+++ b/charts/dify/templates/credentials.tpl
@@ -270,7 +270,9 @@ DIFY_AGENT_REDIS_URL: {{ printf "redis://:%s@%s:%v/2" .auth.password $redisHost 
 DIFY_AGENT_PLUGIN_DAEMON_API_KEY: {{ .Values.pluginDaemon.auth.serverKey | default .Values.global.internalApiKey | b64enc | quote }}
 DIFY_AGENT_INNER_API_KEY: {{ .Values.api.auth.internalApiKey | default .Values.global.internalApiKey | b64enc | quote }}
 {{- end }}
-{{- if .Values.localSandbox.enabled }}
+{{- if .Values.externalE2bSandbox.enabled }}
+DIFY_AGENT_E2B_API_KEY: {{ .Values.externalE2bSandbox.apiKey | b64enc | quote }}
+{{- else if .Values.localSandbox.enabled }}
 DIFY_AGENT_LOCAL_SANDBOX_AUTH_TOKEN: {{ .Values.agentBackend.auth.shellctlAuthToken | b64enc | quote }}
 {{- end }}
 DIFY_AGENT_SERVER_SECRET_KEY: {{ .Values.agentBackend.auth.serverSecretKey | b64enc | quote }}

--- a/charts/dify/templates/e2b-tls-secret.yaml
+++ b/charts/dify/templates/e2b-tls-secret.yaml
@@ -1,0 +1,12 @@
+{{- if and .Values.externalE2bSandbox.enabled .Values.externalE2bSandbox.tls.enabled (not .Values.externalE2bSandbox.tls.existingSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-e2b-tls" (include "dify.fullname" .) }}
+  labels:
+    {{- include "dify.labels" . | nindent 4 }}
+    component: agent-backend
+type: Opaque
+data:
+  {{ .Values.externalE2bSandbox.tls.certCAFilename }}: {{ .Values.externalE2bSandbox.tls.ca | b64enc | quote }}
+{{- end }}

--- a/charts/dify/templates/httproute.yaml
+++ b/charts/dify/templates/httproute.yaml
@@ -84,6 +84,15 @@ spec:
         - name: {{ include "dify.apiWebsocket.fullname" . }}
           port: {{ .Values.apiWebsocket.service.port }}
     {{- end }}
+    {{- if and .Values.externalE2bSandbox.enabled .Values.agentBackend.enabled }}
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /agent-stub
+      backendRefs:
+        - name: {{ include "dify.agentBackend.fullname" . }}
+          port: {{ .Values.agentBackend.service.port }}
+    {{- end }}
     {{- if .Values.web.enabled }}
     - backendRefs:
         - name: {{ include "dify.web.fullname" . }}

--- a/charts/dify/values.schema.json
+++ b/charts/dify/values.schema.json
@@ -1207,6 +1207,13 @@
         }
       }
     },
+    "externalE2bSandbox": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "apiKey": { "type": "string" }
+      }
+    },
     "externalS3": {
       "type": "object",
       "properties": {

--- a/charts/dify/values.schema.json
+++ b/charts/dify/values.schema.json
@@ -1211,7 +1211,19 @@
       "type": "object",
       "properties": {
         "enabled": { "type": "boolean" },
-        "apiKey": { "type": "string" }
+        "domain": { "type": "string" },
+        "apiKey": { "type": "string" },
+        "apiUrl": { "type": "string" },
+        "template": { "type": "string" },
+        "tls": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "existingSecret": { "type": "string" },
+            "certCAFilename": { "type": "string" },
+            "ca": { "type": "string" }
+          }
+        }
       }
     },
     "externalS3": {

--- a/charts/dify/values.yaml
+++ b/charts/dify/values.yaml
@@ -3246,6 +3246,17 @@ externalRedis:
     password: ""
 
 
+## @section External Agent Sandbox
+##
+
+###################################
+# External E2B sandbox
+# - these configs applies only if `externalE2bSandbox.enabled` is true; takes precedence over `localSandbox`
+###################################
+externalE2bSandbox:
+  enabled: false
+  apiKey: ""
+
 ## @Section External storage backend
 ##
 
@@ -3609,6 +3620,10 @@ externalSecret:
       DIFY_AGENT_LOCAL_SANDBOX_AUTH_TOKEN:
         key: "dify/agent-backend"
         property: "shellctl_auth_token"
+      # E2B Cloud API key (`DIFY_AGENT_E2B_API_KEY`). Used only when `externalE2bSandbox.enabled` is true.
+      DIFY_AGENT_E2B_API_KEY:
+        key: "dify/agent-backend"
+        property: "e2b_api_key"
       DIFY_AGENT_PLUGIN_DAEMON_API_KEY:
         key: "dify/plugin-daemon"
         property: "server_key"

--- a/charts/dify/values.yaml
+++ b/charts/dify/values.yaml
@@ -3255,7 +3255,25 @@ externalRedis:
 ###################################
 externalE2bSandbox:
   enabled: false
+  domain: "e2b.app"
   apiKey: ""
+  apiUrl: ""
+  template: ""
+  ## Optional TLS CA for self-hosted / regional E2B suppliers. Official e2b.dev does not need this.
+  ## When enabled, require `existingSecret` or `ca` (`existingSecret` wins). CA only: do not set leaf cert/key.
+  tls:
+    ## @param externalE2bSandbox.tls.enabled Verify the supplier with a custom certificate CA
+    ##
+    enabled: false
+    ## @param externalE2bSandbox.tls.existingSecret Name of a secret containing the certificate CA
+    ##
+    existingSecret: ""
+    ## @param externalE2bSandbox.tls.certCAFilename Path of the certificate CA file when mounted as a secret
+    ##
+    certCAFilename: ca.crt
+    ## @param externalE2bSandbox.tls.ca Content of the certificate CA to be added to the secret
+    ##
+    ca: ""
 
 ## @Section External storage backend
 ##

--- a/ci/values/values-eso-external-s3-pg-es-redis.yaml
+++ b/ci/values/values-eso-external-s3-pg-es-redis.yaml
@@ -483,6 +483,9 @@ externalSecret:
       DIFY_AGENT_LOCAL_SANDBOX_AUTH_TOKEN:
         key: "dify/agent-backend"
         property: "shellctl_auth_token"
+      DIFY_AGENT_E2B_API_KEY:
+        key: "dify/agent-backend"
+        property: "e2b_api_key"
       DIFY_AGENT_PLUGIN_DAEMON_API_KEY:
         key: "dify/plugin-daemon"
         property: "server_key"

--- a/ci/values/values-eso-otel.yaml
+++ b/ci/values/values-eso-otel.yaml
@@ -2536,6 +2536,9 @@ externalSecret:
       DIFY_AGENT_LOCAL_SANDBOX_AUTH_TOKEN:
         key: "dify/agent-backend"
         property: "shellctl_auth_token"
+      DIFY_AGENT_E2B_API_KEY:
+        key: "dify/agent-backend"
+        property: "e2b_api_key"
       DIFY_AGENT_PLUGIN_DAEMON_API_KEY:
         key: "dify/plugin-daemon"
         property: "server_key"

--- a/ci/values/values-eso.yaml
+++ b/ci/values/values-eso.yaml
@@ -2755,6 +2755,9 @@ externalSecret:
       DIFY_AGENT_LOCAL_SANDBOX_AUTH_TOKEN:
         key: "dify/agent-backend"
         property: "shellctl_auth_token"
+      DIFY_AGENT_E2B_API_KEY:
+        key: "dify/agent-backend"
+        property: "e2b_api_key"
       DIFY_AGENT_PLUGIN_DAEMON_API_KEY:
         key: "dify/plugin-daemon"
         property: "server_key"


### PR DESCRIPTION
## Summary
- Add `externalE2bSandbox` so Agent Backend can use E2B (`DIFY_AGENT_RUNTIME_BACKEND=e2b`, `DIFY_AGENT_E2B_API_KEY`) instead of in-cluster `localSandbox`. Workflow Code-node sandbox is unchanged.
- Optional settings for E2B-compatible sandbox suppliers: `E2B_API_URL`, `E2B_DOMAIN`, `DIFY_AGENT_E2B_TEMPLATE`, and a custom CA mount (`SSL_CERT_FILE`).
- When E2B is enabled, publish agentBackend `/agent-stub` on nginx and HTTPRoute (not `/runs`).