### PR TITLE
fix(ci): use utf8mb4 on external MySQL so skills.icon emoji default can migrate

### DIFF
--- a/.github/workflows/ci-eso.yml
+++ b/.github/workflows/ci-eso.yml
@@ -344,6 +344,7 @@ jobs:
             --set auth.database="dify" \
             --set primary.service.type="ClusterIP" \
             --set primary.service.ports.mysql=3306 \
+            --set primary.extraFlags="--character-set-server=utf8mb4 --collation-server=utf8mb4_0900_ai_ci" \
             --wait \
             --timeout 300s
 


### PR DESCRIPTION
## Summary
- The **legacy: using external services (Redis, MySQL, S3)** CI job failed because the API crash-looped while applying the `skills` table migration.
- Dify 1.17.0 creates `skills.icon` as `VARCHAR(16) NOT NULL DEFAULT '📄'`. Bitnami MySQL in CI used `utf8` (`utf8mb3`), which cannot store that emoji default.
- Helm `--wait` then timed out (`rate: Wait(n=1) would exceed context deadline`); web probes and worker `Init` were follow-on failures after API never became ready.
- CI now starts MySQL with `--character-set-server=utf8mb4 --collation-server=utf8mb4_0900_ai_ci`.